### PR TITLE
add selectrum-kill-ring-save command to copy the current candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ how to fix it.
   file\:* type `TAB`. (What this actually does is insert the currently
   selected candidate into the minibuffer, which for `find-file` has
   the effect of navigating into a directory.)
+* *To copy the current candidate:* type `M-w` or what is bind to
+  `kill-ring-save`. When there's an active region in your input, this
+  copies the active region.
 
 Selectrum respects your custom keybindings, so if you've bound
 `next-line` to `M-*` for some reason, then pressing `M-*` will select

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ how to fix it.
   the effect of navigating into a directory.)
 * *To copy the current candidate:* type `M-w` or what is bind to
   `kill-ring-save`. When there's an active region in your input, this
-  copies the active region.
+  still copies the active region. The behavior of `M-w` is not
+  modified when Transient Mark mode is disabled.
 
 Selectrum respects your custom keybindings, so if you've bound
 `next-line` to `M-*` for some reason, then pressing `M-*` will select

--- a/selectrum.el
+++ b/selectrum.el
@@ -497,11 +497,14 @@ provided, rather than providing one of their own."
   "Save current candidate to kill ring.
 Or if there is an active region, save the region to kill ring."
   (interactive)
-  (if (region-active-p)
+  (if (or (use-region-p) (not transient-mark-mode))
       (call-interactively #'kill-ring-save)
-    (when selectrum--current-candidate-index
-      (kill-new (nth selectrum--current-candidate-index
-                     selectrum--refined-candidates)))))
+    (let ((candidate (nth selectrum--current-candidate-index
+                          selectrum--refined-candidates)))
+      (when selectrum--current-candidate-index
+        (kill-new (or (get-text-property
+                       0 'selectrum-candidate-full candidate)
+                      candidate))))))
 
 (defun selectrum-select-current-candidate ()
   "Exit minibuffer, picking the currently selected candidate.

--- a/selectrum.el
+++ b/selectrum.el
@@ -159,6 +159,7 @@ strings."
     ([remap scroll-up-command]   . selectrum-next-page)
     ([remap beginning-of-buffer] . selectrum-goto-beginning)
     ([remap end-of-buffer]       . selectrum-goto-end)
+    ([remap kill-ring-save]      . selectrum-kill-ring-save)
     ("C-j"                       . selectrum-submit-exact-input)
     ("TAB"                       . selectrum-insert-current-candidate))
   "Keybindings enabled in minibuffer. This is not a keymap.
@@ -491,6 +492,16 @@ provided, rather than providing one of their own."
   (when selectrum--current-candidate-index
     (setq selectrum--current-candidate-index
           (1- (length selectrum--refined-candidates)))))
+
+(defun selectrum-kill-ring-save ()
+  "Save current candidate to kill ring.
+Or if there is an active region, save the region to kill ring."
+  (interactive)
+  (if (region-active-p)
+      (call-interactively #'kill-ring-save)
+    (when selectrum--current-candidate-index
+      (kill-new (nth selectrum--current-candidate-index
+                     selectrum--refined-candidates)))))
 
 (defun selectrum-select-current-candidate ()
   "Exit minibuffer, picking the currently selected candidate.


### PR DESCRIPTION
One thing I'm not sure is whether to do the `'selectrum-candidate-full` thing like in `selectrum-insert-current-candidate`. I think normally the user want to copy what he see, so copying the full path would be confusing. But on the other hand, now the suffix for directories won't be copied.