### PR TITLE
fix: in selectrum-read-file-name, handle initial/default-filename

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -759,7 +759,7 @@ PREDICATE, see `read-file-name'."
                           (file-name-nondirectory
                            (directory-file-name default)))
      :initial-input (if-let ((default (or initial default-filename)))
-                        (expand-file-name (directory-file-name default) dir)
+                        (expand-file-name default dir)
                       dir)
      :require-match mustmatch)))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -709,9 +709,6 @@ For PROMPT, DIR, DEFAULT-FILENAME, MUSTMATCH, INITIAL, and
 PREDICATE, see `read-file-name'."
   (let* ((dir (file-name-as-directory
                (expand-file-name (or dir default-directory))))
-         (full-path (if (or initial default-filename)
-                        (expand-file-name (or initial default-filename) dir)
-                      dir))
          (orig-preprocess-function selectrum-preprocess-candidates-function)
          (orig-refine-function selectrum-refine-candidates-function)
          (selectrum-preprocess-candidates-function #'ignore)
@@ -758,13 +755,12 @@ PREDICATE, see `read-file-name'."
                 (input . ,new-input))))))
     (selectrum-read
      prompt nil
-     :default-candidate (when (and (file-exists-p full-path)
-                                   (not (string-empty-p
-                                         (file-name-nondirectory full-path))))
-                          (file-name-nondirectory full-path))
-     :initial-input (if (file-exists-p full-path)
-                        (file-name-directory full-path)
-                      full-path)
+     :default-candidate (when-let ((default (or initial default-filename)))
+                          (file-name-nondirectory
+                           (directory-file-name default)))
+     :initial-input (if-let ((default (or initial default-filename)))
+                        (expand-file-name (directory-file-name default) dir)
+                      dir)
      :require-match mustmatch)))
 
 (defvar selectrum--old-read-file-name-function nil

--- a/selectrum.el
+++ b/selectrum.el
@@ -709,6 +709,9 @@ For PROMPT, DIR, DEFAULT-FILENAME, MUSTMATCH, INITIAL, and
 PREDICATE, see `read-file-name'."
   (let* ((dir (file-name-as-directory
                (expand-file-name (or dir default-directory))))
+         (full-path (if (or initial default-filename)
+                        (expand-file-name (or initial default-filename) dir)
+                      dir))
          (orig-preprocess-function selectrum-preprocess-candidates-function)
          (orig-refine-function selectrum-refine-candidates-function)
          (selectrum-preprocess-candidates-function #'ignore)
@@ -755,10 +758,13 @@ PREDICATE, see `read-file-name'."
                 (input . ,new-input))))))
     (selectrum-read
      prompt nil
-     :default-candidate (when-let ((default (or initial default-filename)))
-                          (file-name-nondirectory
-                           (directory-file-name default)))
-     :initial-input dir
+     :default-candidate (when (and (file-exists-p full-path)
+                                   (not (string-empty-p
+                                         (file-name-nondirectory full-path))))
+                          (file-name-nondirectory full-path))
+     :initial-input (if (file-exists-p full-path)
+                        (file-name-directory full-path)
+                      full-path)
      :require-match mustmatch)))
 
 (defvar selectrum--old-read-file-name-function nil


### PR DESCRIPTION
Here's an example:

```
(read-file-name "File: " "/home/" nil nil "name")
```

With `selectrum-mode` enabled, the minibuffer is:

```
1    File: /home/
kino/
```

With `selectrum-mode` disabled, it is:

```
File: /home/name
```

So their behavior is not consistent.

Selectrum actually selects a default candidate based on `initial` or `default-filename`. But when `mustmatch` is nil, the caller of `read-file-name` may want to save some file on disk, and it has a preferred file name that's not presented in the disk. This patch handles this situation.

The problem is: when the given `initial` or `default-filename` actually matches a candidate, it will still be in the user input, which is inconsistent with the behavior of `selectrum-read-file-name` in other situations. I've not find a simple way to detect if there's this match.