### PR TITLE
Make prompt selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ how to fix it.
   (`<up>`, `<down>`, `C-v`, `M-v`, `M-<`, `M->`). If you prefer, you
   can use `C-p` and `C-n` instead of the arrow keys.
 * *To accept the currently selected candidate:* type `RET`.
-* *To submit what you've typed, even if it's not a candidate:* type
-  `C-j`.
+* *To submit what you've typed, even if it's not a candidate:* select
+  the prompt like a regular candidate using `C-p` and submit like usual
+  (alternatively use `C-j` to submit without selecting the prompt first).
 * *To abort:* as per usual, type `C-g`.
 * *To navigate into the currently selected directory while finding a
   file\:* type `TAB`. (What this actually does is insert the currently

--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ how to fix it.
   (`<up>`, `<down>`, `C-v`, `M-v`, `M-<`, `M->`). If you prefer, you
   can use `C-p` and `C-n` instead of the arrow keys.
 * *To accept the currently selected candidate:* type `RET`.
-* *To submit what you've typed, even if it's not a candidate:* select
-  the prompt like a regular candidate using `C-p` and submit like usual
-  (alternatively use `C-j` to submit without selecting the prompt first).
+* *To submit what you've typed, even if it's not a candidate:* you can
+  use `<up>` or `C-p` to select the user input just like a regular
+  candidate, and type `RET` as usual. (Alternatively, you can type
+  `C-j` to submit your exact input without selecting it first.)
 * *To abort:* as per usual, type `C-g`.
 * *To navigate into the currently selected directory while finding a
   file\:* type `TAB`. (What this actually does is insert the currently

--- a/selectrum.el
+++ b/selectrum.el
@@ -542,9 +542,13 @@ Or if there is an active region, save the region to kill ring."
   (interactive)
   (if (or (use-region-p) (not transient-mark-mode))
       (call-interactively #'kill-ring-save)
-    (let ((candidate (nth selectrum--current-candidate-index
-                          selectrum--refined-candidates)))
-      (when selectrum--current-candidate-index
+    (when selectrum--current-candidate-index
+      (let ((candidate (if (< selectrum--current-candidate-index 0)
+                           (buffer-substring-no-properties
+                            selectrum--start-of-input-marker
+                            selectrum--end-of-input-marker)
+                         (nth selectrum--current-candidate-index
+                              selectrum--refined-candidates))))
         (kill-new (or (get-text-property
                        0 'selectrum-candidate-full candidate)
                       candidate))))))

--- a/selectrum.el
+++ b/selectrum.el
@@ -554,7 +554,7 @@ Or if there is an active region, save the region to kill ring."
                       candidate))))))
 
 (defun selectrum--exit-with (value)
-  "Exit minibuffer with value."
+  "Exit minibuffer with VALUE."
   (remove-text-properties
    0 (length value)
    '(face selectrum-current-candidate) value)

--- a/selectrum.el
+++ b/selectrum.el
@@ -496,7 +496,8 @@ provided, rather than providing one of their own."
   (interactive)
   (when selectrum--current-candidate-index
     (setq selectrum--current-candidate-index
-          (max -1 (1- selectrum--current-candidate-index)))))
+          (max (if selectrum--match-required-p 0 -1)
+               (1- selectrum--current-candidate-index)))))
 
 (defun selectrum-next-candidate ()
   "Move selection to next candidate, unless at end already."

--- a/selectrum.el
+++ b/selectrum.el
@@ -579,6 +579,9 @@ ignores the currently selected candidate, if one exists."
     (let ((value (buffer-substring
                   selectrum--start-of-input-marker
                   selectrum--end-of-input-marker)))
+      (remove-text-properties
+       0 (length value)
+       '(face selectrum-current-candidate) value)
       (let ((inhibit-read-only t))
         (erase-buffer)
         (insert value))

--- a/selectrum.el
+++ b/selectrum.el
@@ -414,8 +414,10 @@ Passed to various hook functions.")
           (setq displayed-candidates
                 (seq-take displayed-candidates
                           selectrum-num-candidates-displayed))
-          (if (and highlighted-index
-                   (< highlighted-index 0))
+          (if (or (and highlighted-index
+                       (< highlighted-index 0))
+                  (and (not selectrum--match-required-p)
+                       (not displayed-candidates)))
               (add-text-properties
                (minibuffer-prompt-end) bound
                '(face selectrum-current-candidate))


### PR DESCRIPTION
Coming from ivy I missed the feature of being able to select the prompt. With this patch one can select the prompt instead of using `selectrum-submit-exact-input`. I haven't introduced a user option because I think there is nothing wrong with allowing this behavior by default. 

To test:

- Invoke  `find-file`
- Type some chars which match existing candidates
- Instead of accepting input with `C-j` you can now do `C-p RET`

This features frees the user of having to remember a keybinding for this action.