### PR TITLE
Don't possibly return `nil' in `selectrum-read'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### Bugs fixed
-* `selectrum-read` no longer returns nil when no default value was
+* `selectrum-read` no longer returns nil when no default value wasn't
 given and the empty prompt was submitted. This breaks commands which
 assume an empty string when selecting no value.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### Bugs fixed
-* `selectrum-read` no longer returns nil when no default value wasn't
+* `selectrum-read` no longer returns nil when no default value was
 given and the empty prompt was submitted. This breaks commands which
 assume an empty string when selecting no value.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Bugs fixed
+* `selectrum-read` no longer returns nil when no default value was
+given and the empty prompt was submitted. This breaks commands which
+assume an empty string when selecting no value.
+
 ## 1.0 (released 2020-03-23)
 ### Added
 * Package `selectrum`

--- a/selectrum.el
+++ b/selectrum.el
@@ -665,7 +665,7 @@ no effect)."
               (or (get-text-property 0 'selectrum-candidate-full selected)
                   selected)))
         (prog1 (if (string-empty-p full)
-                   default-candidate
+                   (or default-candidate "")
                  full)
           (apply
            #'run-hook-with-args


### PR DESCRIPTION
Submitting the empty prompt needs to return the empty string, currently when no default-candidate is given nil is returned which breaks some commands. This is also how default `completing-read` behaves.