### PR TITLE
add: a text property for display string in the right margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ The format is based on [Keep a Changelog].
 * We now bind `minibuffer-completing-file-name` during
   `read-file-name`, in conformance with the standard Emacs interface
   ([#30]).
+* A new text property `selectrum-candidate-display-right-margin` is
+  added, to display a string at the right margin after a candidate
+  ([#44]).
 
 ## Bugs fixed
 * You can now use the undo system in the minibuffer. Previously,
@@ -50,6 +53,7 @@ The format is based on [Keep a Changelog].
 [#32]: https://github.com/raxod502/selectrum/issues/32
 [#33]: https://github.com/raxod502/selectrum/pull/33
 [#34]: https://github.com/raxod502/selectrum/pull/34
+[#44]: https://github.com/raxod502/selectrum/pull/44
 
 ## 1.0 (released 2020-03-23)
 ### Added

--- a/README.md
+++ b/README.md
@@ -342,6 +342,14 @@ which may be applied to candidates using `propertize`:
   `find-file`, the canonical representation of each candidate is its
   absolute path on the filesystem.
 
+Besides, we have:
+
+* `selectrum-candidate-display-right-margin`: if this property is
+  presented, its value is displayed at the right margin after the
+  candidate. Currently Selectrum doesn't make use of this property. It
+  can be used to display supplementary information in user-defined
+  commands.
+
 Note that sorting, filtering, and highlighting is done on the standard
 values of candidates, before any of these text properties are handled.
 


### PR DESCRIPTION
See https://github.com/raxod502/selectrum/issues/14

The right margin text is displayed in the same line:

![image](https://user-images.githubusercontent.com/28714352/78900423-6a515c00-7aa9-11ea-9b41-9ed486c90097.png)

or in a new line, when the space is not enough:

![image](https://user-images.githubusercontent.com/28714352/78900540-8b19b180-7aa9-11ea-8b72-c86b8f7063e5.png)
