### PR TITLE
Use `read-file-name-default` for reading files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ The format is based on [Keep a Changelog].
   should be available now. Most notably you can now use `M-n` to
   insert file names into the minibuffer (using
   `file-name-at-point-functions`) and you are able to use shortcuts
-  like `//` or `~/` ([#50]).
+  like `//` or `~/` ([#50], [#52]).
 * When reading directories using `read-directory-name` the default is
   sorted to the top instead of inserting it ([#50]).
 * In `read-file-name`, when a default is provided (for example in the
@@ -108,6 +108,7 @@ The format is based on [Keep a Changelog].
 [#38]: https://github.com/raxod502/selectrum/pull/38
 [#39]: https://github.com/raxod502/selectrum/issues/39
 [#44]: https://github.com/raxod502/selectrum/pull/44
+[#52]: https://github.com/raxod502/selectrum/issues/52
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,13 @@ The format is based on [Keep a Changelog].
   similar functionality to `ivy-avy`. See [#16].
 
 ### Enhancements
-* `selectrum-read-file-name` which is used as `read-file-name-function` now uses
-  `read-file-name-default` internally. This means all default features of file
-  completion should be available now. Most notably you can now use `M-n` to
-  insert file names into the minibuffer (using `file-name-at-point-functions`)
-  and you are able to use shortcuts like `//` or `~/` ([#50]).
+* `selectrum-read-file-name` which is used as
+  `read-file-name-function` now uses `read-file-name-default`
+  internally. This means all default features of file completion
+  should be available now. Most notably you can now use `M-n` to
+  insert file names into the minibuffer (using
+  `file-name-at-point-functions`) and you are able to use shortcuts
+  like `//` or `~/` ([#50]).
 * In `read-file-name`, when a default is provided (for example in the
   `dired-do-rename` command), we actually use it as the initial
   contents of the minibuffer, which allows you to have convenient

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@ The format is based on [Keep a Changelog].
   similar functionality to `ivy-avy`. See [#16].
 
 ### Enhancements
+* `selectrum-read-file-name` which is used as `read-file-name-function` now uses
+  `read-file-name-default` internally. This means all default features of file
+  completion should be available now. Most notably you can now use `M-n` to
+  insert file names into the minibuffer (using `file-name-at-point-functions`)
+  and you are able to use shortcuts like `//` or `~/` ([#50]).
 * In `read-file-name`, when a default is provided (for example in the
   `dired-do-rename` command), we actually use it as the initial
   contents of the minibuffer, which allows you to have convenient

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ The format is based on [Keep a Changelog].
   insert file names into the minibuffer (using
   `file-name-at-point-functions`) and you are able to use shortcuts
   like `//` or `~/` ([#50]).
+* When reading directories using `read-directory-name` the default is
+  sorted to the top instead of inserting it ([#50]).
 * In `read-file-name`, when a default is provided (for example in the
   `dired-do-rename` command), we actually use it as the initial
   contents of the minibuffer, which allows you to have convenient

--- a/selectrum.el
+++ b/selectrum.el
@@ -889,7 +889,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                        (dir (or (file-name-directory input) ""))
                        ;; the input used for matching current dir entries
                        (ematch (file-name-nondirectory input))
-                       ;; adjust original collection for selectrum
+                       ;; Adjust original collection for Selectrum.
                        (cands (funcall collection dir
                                        (lambda (i)
                                          (when (and (or (not predicate)

--- a/selectrum.el
+++ b/selectrum.el
@@ -887,7 +887,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
   (let ((coll (lambda (input)
                 (let* (;; full path of input dir (might include shadowed parts)
                        (dir (or (file-name-directory input) ""))
-                       ;; the input used for matching current dir entries
+                       ;; The input used for matching current dir entries.
                        (ematch (file-name-nondirectory input))
                        ;; Adjust original collection for Selectrum.
                        (cands (funcall collection dir

--- a/selectrum.el
+++ b/selectrum.el
@@ -890,18 +890,22 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                        ;; The input used for matching current dir entries.
                        (ematch (file-name-nondirectory input))
                        ;; Adjust original collection for Selectrum.
-                       (cands (funcall collection dir
-                                       (lambda (i)
-                                         (when (and (or (not predicate)
-                                                        (funcall predicate i))
-                                                    (not (member
-                                                          i '("./" "../"))))
-                                           (prog1 t
-                                             (add-text-properties
-                                              0 (length i)
-                                              `(selectrum-candidate-full
-                                                ,(concat dir i)) i))))
-                                       t)))
+                       (cands (condition-case _
+                                  (funcall collection dir
+                                           (lambda (i)
+                                             (when (and (or (not predicate)
+                                                            (funcall predicate i))
+                                                        (not (member
+                                                              i '("./" "../"))))
+                                               (prog1 t
+                                                 (add-text-properties
+                                                  0 (length i)
+                                                  `(selectrum-candidate-full
+                                                    ,(concat dir i)) i))))
+                                           t)
+                                ;; May happen in case user quits out
+                                ;; of a TRAMP prompt.
+                                (quit))))
                   `((input . ,ematch)
                     (candidates . ,cands))))))
     (selectrum-read

--- a/selectrum.el
+++ b/selectrum.el
@@ -885,7 +885,7 @@ PREDICATE, see `read-file-name'."
 For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
             HIST, DEF, _INHERIT-INPUT-METHOD see `completing-read'."
   (let ((coll (lambda (input)
-                (let* (;; full path of input dir (might include shadowed parts)
+                (let* (;; Full path of input dir (might include shadowed parts).
                        (dir (or (file-name-directory input) ""))
                        ;; The input used for matching current dir entries.
                        (ematch (file-name-nondirectory input))

--- a/selectrum.el
+++ b/selectrum.el
@@ -884,33 +884,35 @@ PREDICATE, see `read-file-name'."
   "Selectrums completing read function for `read-file-name-default'.
 For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
             HIST, DEF, _INHERIT-INPUT-METHOD see `completing-read'."
-  (let ((coll (lambda (input)
-                (let* (;; Full path of input dir (might include shadowed parts).
-                       (dir (or (file-name-directory input) ""))
-                       ;; The input used for matching current dir entries.
-                       (ematch (file-name-nondirectory input))
-                       ;; Adjust original collection for Selectrum.
-                       (cands (condition-case _
-                                  (funcall collection dir
-                                           (lambda (i)
-                                             (when (and (or (not predicate)
-                                                            (funcall predicate i))
-                                                        (not (member
-                                                              i '("./" "../"))))
-                                               (prog1 t
-                                                 (add-text-properties
-                                                  0 (length i)
-                                                  `(selectrum-candidate-full
-                                                    ,(concat dir i)) i))))
-                                           t)
-                                ;; May happen in case user quits out
-                                ;; of a TRAMP prompt.
-                                (quit))))
-                  `((input . ,ematch)
-                    (candidates . ,cands))))))
+  (let ((coll
+         (lambda (input)
+           (let* (;; Full path of input dir (might include shadowed parts).
+                  (dir (or (file-name-directory input) ""))
+                  ;; The input used for matching current dir entries.
+                  (ematch (file-name-nondirectory input))
+                  ;; Adjust original collection for Selectrum.
+                  (cands
+                   (condition-case _
+                       (funcall collection dir
+                                (lambda (i)
+                                  (when (and (or (not predicate)
+                                                 (funcall predicate i))
+                                             (not (member
+                                                   i '("./" "../"))))
+                                    (prog1 t
+                                      (add-text-properties
+                                       0 (length i)
+                                       `(selectrum-candidate-full
+                                         ,(concat dir i)) i))))
+                                t)
+                     ;; May happen in case user quits out
+                     ;; of a TRAMP prompt.
+                     (quit))))
+             `((input . ,ematch)
+               (candidates . ,cands))))))
     (selectrum-read
      prompt coll
-     :default-candidate  (or (car-safe def) def)
+     :default-candidate (or (car-safe def) def)
      :initial-input (or (car-safe initial-input) initial-input)
      :history hist
      :require-match require-match)))


### PR DESCRIPTION
Using `read-file-name-default` has many advantages because it takes care of any
additional minibuffer setup for file completion. Also any upstream changes for reading file names are automatically picked up.

Variables like `minibuffer-completing-file-name` are set automatically and you have additional features like using `M-n` to run file at point functions (which inserts the file path at point
into the minibuffer). Also `file-shadow-mode` and `tramp` work without additional changes.