### PR TITLE
Run `selectrum-candidate-selected-hook` on exit

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -670,12 +670,16 @@ Or if there is an active region, save the region to kill ring."
   (remove-text-properties
    0 (length value)
    '(face selectrum-current-candidate) value)
+  (apply
+   #'run-hook-with-args
+   'selectrum-candidate-selected-hook
+   value selectrum--read-args)
   (let ((inhibit-read-only t))
     (erase-buffer)
     (insert (or (get-text-property 0 'selectrum-candidate-full
                                    value)
-                value)))
-  (exit-minibuffer))
+                value))
+    (exit-minibuffer)))
 
 (defun selectrum-select-current-candidate ()
   "Exit minibuffer, picking the currently selected candidate.
@@ -794,13 +798,9 @@ select one of the listed candidates (so, for example,
              (enable-recursive-minibuffers nil)
              (minibuffer-history-variable history)
              (selected (read-from-minibuffer prompt nil keymap nil history)))
-        (prog1 (if (string-empty-p selected)
-                   (or default-candidate "")
-                 selected)
-          (apply
-           #'run-hook-with-args
-           'selectrum-candidate-selected-hook
-           selected selectrum--read-args))))))
+        (if (string-empty-p selected)
+            (or default-candidate "")
+          selected)))))
 
 ;;;###autoload
 (defun selectrum-completing-read


### PR DESCRIPTION
Inserting the full value on exit introduced a regression because `selectrum-candidate-selected-hook` currently gets always passed the full candidate but it needs the actual selected value.