### PR TITLE
Add inserted candidates to history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog].
   See [#27].
 
 ### Features
+* Candidates inserted by `selectrum-insert-current-candidate` are now
+  added to history ([#54]).
 * You can resume the last completion session using the
   `selectrum-repeat` command. (Note that you must bind this command to
   a key sequence in order to use it.) This command implements similar
@@ -125,6 +127,7 @@ The format is based on [Keep a Changelog].
 [#44]: https://github.com/raxod502/selectrum/pull/44
 [#49]: https://github.com/raxod502/selectrum/issues/49
 [#52]: https://github.com/raxod502/selectrum/issues/52
+[#54]: https://github.com/raxod502/selectrum/pull/54
 [#55]: https://github.com/raxod502/selectrum/issues/55
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -754,11 +754,13 @@ ignores the currently selected candidate, if one exists."
   (when selectrum--current-candidate-index
     (delete-region selectrum--start-of-input-marker
                    selectrum--end-of-input-marker)
-    (let ((candidate (nth selectrum--current-candidate-index
-                          selectrum--refined-candidates)))
-      (insert (or (get-text-property
-                   0 'selectrum-candidate-full candidate)
-                  candidate))
+    (let* ((candidate (nth selectrum--current-candidate-index
+                           selectrum--refined-candidates))
+           (full (or (get-text-property
+                      0 'selectrum-candidate-full candidate)
+                     candidate)))
+      (insert full)
+      (add-to-history minibuffer-history-variable full)
       (apply
        #'run-hook-with-args
        'selectrum-candidate-inserted-hook


### PR DESCRIPTION
I first thought about adding this to the `selectrum-candidate-inserted-hook` in my config and checking for `(eq this-command selectrum-insert-current-candidate)` but I think it might be generally useful to add those candidates to history. What do you think?
