### PR TITLE
[#42] Utilize annotation and docsig function in completion-in-region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,10 @@ The format is based on [Keep a Changelog].
 * We provide a `selectrum-completion-in-region` function now and
   install it on `completion-in-region-function` in `selectrum-mode`,
   so `completion-at-point` will use Selectrum when there is more than
-  one completion ([#42]).
+  one completion ([#42]). This function can display annotation
+  informations if the `completion-at-point-function` backend offers
+  them, and they use the face `selectrum-completion-annotation`
+  ([#62]).
 
 ### Enhancements
 * `selectrum-read-file-name` which is used as
@@ -150,6 +153,7 @@ The format is based on [Keep a Changelog].
 [#53]: https://github.com/raxod502/selectrum/issues/53
 [#54]: https://github.com/raxod502/selectrum/pull/54
 [#55]: https://github.com/raxod502/selectrum/issues/55
+[#62]: https://github.com/raxod502/selectrum/pull/62
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ matching and case-insensitive matching.
   in telling you what prefix argument you should pass to
   `selectrum-select-current-candidate` in order to select a given
   candidate.
+* The `selectrum-completion-in-region` function can display annotations
+  if the `completion-in-region-function` backend offers them. Customize
+  the face `selectrum-completion-annotation` to change their appearance.
 
 As an example of customizing the faces, I use the
 [Zerodark](https://github.com/NicolasPetton/zerodark-theme) color

--- a/selectrum.el
+++ b/selectrum.el
@@ -1148,12 +1148,12 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                  (lambda (cand)
                    (propertize
                     cand
-                    'selectrum-candidate-display-prefix
+                    'selectrum-candidate-display-suffix
                     (when annotation-func
                       ;; Rule out situations where the annotation is nil.
                       (when-let (annotation (funcall annotation-func cand))
                         (propertize
-                         (format "%-12s" annotation)
+                         annotation
                          'face 'selectrum-completion-annotation)))
                     'selectrum-candidate-display-right-margin
                     (when docsig-func

--- a/selectrum.el
+++ b/selectrum.el
@@ -1151,13 +1151,13 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                     'selectrum-candidate-display-suffix
                     (when annotation-func
                       ;; Rule out situations where the annotation is nil.
-                      (when-let (annotation (funcall annotation-func cand))
+                      (when-let ((annotation (funcall annotation-func cand)))
                         (propertize
                          annotation
                          'face 'selectrum-completion-annotation)))
                     'selectrum-candidate-display-right-margin
                     (when docsig-func
-                      (when-let (docsig (funcall docsig-func cand))
+                      (when-let ((docsig (funcall docsig-func cand)))
                         (propertize
                          (format "%s" docsig)
                          'face 'selectrum-completion-annotation)))))


### PR DESCRIPTION
This implements ideas mentioned in https://github.com/raxod502/selectrum/issues/42#issuecomment-614379709.

## How does it look like

![image](https://user-images.githubusercontent.com/28714352/79683476-f9563500-825c-11ea-9bbb-97f8a781daab.png)

This is `selectrum-completion-in-region` on a backend created by me. I use the `:annotation-function` for the kind (variable, function, ...), which is displayed as the prefix; and I use the `:company-docsig` for the signature, which is displayed using right-margin text.

## How does it work

The `completion-at-point` function let binds `completion-extra-properties` to the extra props offered by backends, so we could just get the things we need from it.

## What can still be improved

- I use a italic face for those annotations, but I think it's better to also use some gray color to distinguish them from the candidate. Are you ok with me adding such face?

- Maybe we should also handle `:exit-function` (see the docstring of `completion-extra-properties`). I haven't study what is it for. company-capf also handles `:predicate` (see the docstring of `completion-at-point-functions`.