### PR TITLE
Improve default handling

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -42,6 +42,7 @@
 (require 'regexp-opt)
 (require 'seq)
 (require 'subr-x)
+(require 'minibuf-eldef)
 
 ;;;; Faces
 
@@ -356,6 +357,24 @@ If PREDICATE is non-nil, then it filters the collection as in
   (or (get-text-property 0 'selectrum-candidate-full candidate)
       candidate))
 
+(defvar selectrum--minibuffer-default-prompt-regexps
+  (let ((minibuffer-eldef-shorten-default nil))
+    (cl-remove-if (lambda (i) (and (consp i) (nth 2 i)))
+                  (minibuffer-default--in-prompt-regexps)))
+  "See `minibuffer-default-in-prompt-regexps'.")
+
+(defun selectrum--replace-default-in-prompt (prompt)
+  "Remove default indication from PROMPT."
+  (let ((regexps selectrum--minibuffer-default-prompt-regexps))
+    (cl-dolist (matcher regexps prompt)
+      (let ((regex (if (stringp matcher) matcher (car matcher))))
+        (when (string-match regex prompt)
+          (cl-return
+           (replace-match "" nil nil prompt
+                          (if (consp matcher)
+                              (cadr matcher)
+                            0))))))))
+
 ;;;; Minibuffer state
 
 (defvar selectrum--start-of-input-marker nil
@@ -639,8 +658,7 @@ just rendering it to the screen and then checking."
               (if (= (minibuffer-prompt-end) bound)
                   (let ((str
                          (propertize
-                          (format " [default value: %S]"
-                                  (or selectrum--default-candidate 'none))
+                          (format " [submit empty string]")
                           'face 'minibuffer-prompt))
                         (ol (make-overlay
                              (minibuffer-prompt-end)
@@ -808,7 +826,10 @@ into the user input area to start with."
   (interactive)
   (when selectrum--current-candidate-index
     (setq selectrum--current-candidate-index
-          (max (if selectrum--match-required-p 0 -1)
+          (max (if (or (not selectrum--default-candidate)
+                       minibuffer-completing-file-name)
+                   -1
+                 0)
                (1- selectrum--current-candidate-index)))))
 
 (defun selectrum-next-candidate ()
@@ -1082,6 +1103,7 @@ is very confusing."
                (resize-mini-windows 'grow-only)
                (max-mini-window-height
                 (1+ selectrum-num-candidates-displayed))
+               (prompt (selectrum--replace-default-in-prompt prompt))
                ;; Need to bind this back to its standard value due to
                ;; <https://github.com/raxod502/selectrum/issues/61>.
                ;; What happens is `selectrum-read-file-name' binds


### PR DESCRIPTION
Because the default is sorted to the top or shown in overlay when selecting the empty prompt there is no point in showing it in the prompt (I think it is distracting with selectrums model).

This PR also fixes #67 so that the empty string can be submitted regardless of the require-match setting. If there is a default value it's already at the top so there is no point to submit the empty string (which just selects the default), hence selecting the empty prompt when a default value exists is inhibited.
