### PR TITLE
Improve default handling and prompt selection (fix #67)

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -669,9 +669,7 @@ START and END are positions for highlighting."
                                    (let ((ol (make-overlay
                                               selectrum--end-of-input-marker
                                               selectrum--end-of-input-marker))
-                                         (td (propertize
-                                              selectrum--default-candidate
-                                              'face 'shadow)))
+                                         (td selectrum--default-candidate))
                                      (put-text-property 0 1 'cursor t td)
                                      (overlay-put ol 'after-string td)
                                      (setq selectrum--transient-default-overlay

--- a/selectrum.el
+++ b/selectrum.el
@@ -597,7 +597,15 @@ just rendering it to the screen and then checking."
                                   selectrum--default-candidate)
                              (selectrum--move-to-front-destructive
                               selectrum--default-candidate
-                              cands (not minibuffer-completing-file-name))
+                              cands
+                              ;; Imenu blindly uses symbol-at-point as default
+                              ;; which might not be an actual candidate which
+                              ;; makes no sense for imenu and is confusing.
+                              (if (eq minibuffer-history-variable
+                                      'imenu--history-list)
+                                  (and (member selectrum--default-candidate
+                                               cands))
+                                (not minibuffer-completing-file-name)))
                            cands))))
         (when (and input (not (string-empty-p input)))
           (setq selectrum--refined-candidates

--- a/selectrum.el
+++ b/selectrum.el
@@ -690,6 +690,7 @@ START and END are positions for highlighting."
               (setq selectrum--repeat nil))
           (setq selectrum--current-candidate-index
                 (cond
+                 (selectrum--transient-default-overlay -1)
                  ((null selectrum--refined-candidates)
                   nil)
                  (selectrum--move-default-candidate-p

--- a/selectrum.el
+++ b/selectrum.el
@@ -287,11 +287,13 @@ new one."
       (setcar lst (funcall func (car lst)))
       (setq lst (cdr lst)))))
 
-(defun selectrum--move-to-front-destructive (elt lst)
+(defun selectrum--move-to-front-destructive (elt lst &optional add)
   "Move all instances of ELT to front of LST, if present.
-Make comparisons using `equal'. Modify the input list
-destructively and return the modified list."
+If ADD is non-nil add element if not present. Make comparisons
+using `equal'. Modify the input list destructively and return the
+modified list."
   (let* ((elts nil)
+         (found nil)
          ;; All problems in computer science are solved by an
          ;; additional layer of indirection.
          (lst (cons (make-symbol "dummy") lst))
@@ -299,10 +301,14 @@ destructively and return the modified list."
     (while (cdr link)
       (if (equal elt (cadr link))
           (progn
+            (setq found t)
             (push (cadr link) elts)
             (setcdr link (cddr link)))
         (setq link (cdr link))))
-    (nconc (nreverse elts) (cdr lst))))
+    (nconc (if (and elt add (not found))
+               (cons elt (nreverse elts))
+             (nreverse elts))
+           (cdr lst))))
 
 (defun selectrum--normalize-collection (collection &optional predicate)
   "Normalize COLLECTION into a list of strings.
@@ -591,7 +597,7 @@ just rendering it to the screen and then checking."
           (setq selectrum--refined-candidates
                 (selectrum--move-to-front-destructive
                  selectrum--default-candidate
-                 selectrum--refined-candidates)))
+                 selectrum--refined-candidates t)))
         (setq selectrum--refined-candidates
               (selectrum--move-to-front-destructive
                input selectrum--refined-candidates))

--- a/selectrum.el
+++ b/selectrum.el
@@ -592,12 +592,13 @@ just rendering it to the screen and then checking."
                                       (alist-get 'candidates result))))
                        selectrum--preprocessed-candidates)))
           (setq selectrum--refined-candidates
-                (funcall selectrum-refine-candidates-function input cands)))
-        (when selectrum--move-default-candidate-p
-          (setq selectrum--refined-candidates
-                (selectrum--move-to-front-destructive
-                 selectrum--default-candidate
-                 selectrum--refined-candidates t)))
+                (funcall selectrum-refine-candidates-function input
+                         (if (and selectrum--move-default-candidate-p
+                                  selectrum--default-candidate)
+                             (selectrum--move-to-front-destructive
+                              selectrum--default-candidate
+                              cands t)
+                           cands))))
         (setq selectrum--refined-candidates
               (selectrum--move-to-front-destructive
                input selectrum--refined-candidates))

--- a/selectrum.el
+++ b/selectrum.el
@@ -597,7 +597,7 @@ just rendering it to the screen and then checking."
                                   selectrum--default-candidate)
                              (selectrum--move-to-front-destructive
                               selectrum--default-candidate
-                              cands t)
+                              cands (not minibuffer-completing-file-name))
                            cands))))
         (setq selectrum--refined-candidates
               (selectrum--move-to-front-destructive

--- a/selectrum.el
+++ b/selectrum.el
@@ -599,9 +599,10 @@ just rendering it to the screen and then checking."
                               selectrum--default-candidate
                               cands (not minibuffer-completing-file-name))
                            cands))))
-        (setq selectrum--refined-candidates
-              (selectrum--move-to-front-destructive
-               input selectrum--refined-candidates))
+        (when (and input (not (string-empty-p input)))
+          (setq selectrum--refined-candidates
+                (selectrum--move-to-front-destructive
+                 input selectrum--refined-candidates)))
         (if selectrum--repeat
             (progn
               (setq selectrum--current-candidate-index

--- a/selectrum.el
+++ b/selectrum.el
@@ -39,10 +39,10 @@
 
 (require 'cl-lib)
 (require 'map)
+(require 'minibuf-eldef)
 (require 'regexp-opt)
 (require 'seq)
 (require 'subr-x)
-(require 'minibuf-eldef)
 
 ;;;; Faces
 
@@ -289,9 +289,9 @@ new one."
 
 (defun selectrum--move-to-front-destructive (elt lst &optional add)
   "Move all instances of ELT to front of LST, if present.
-If ADD is non-nil add element if not present. Make comparisons
-using `equal'. Modify the input list destructively and return the
-modified list."
+If ADD is non-nil add element to start of LST if not present.
+Make comparisons using `equal'. Modify the input list
+destructively and return the modified list."
   (let* ((elts nil)
          (found nil)
          ;; All problems in computer science are solved by an
@@ -836,17 +836,17 @@ into the user input area to start with."
     (setq selectrum--current-candidate-index
           (max (cond ((and selectrum--match-required-p
                            (not selectrum--default-candidate))
-                      ;; allow submitting the empty string
+                      ;; Allow submitting the empty string.
                       -1)
                      ((and (not selectrum--match-required-p)
                            (or (not selectrum--default-candidate)
                                (and selectrum--previous-input-string
                                     (not (string-empty-p
                                           selectrum--previous-input-string)))))
-                      ;; when match is not required but there is a default
-                      ;; candidate only allow selecting when prompt isn't
-                      ;; empty because the default candidate is already
-                      ;; selected anyway
+                      ;; When match is not required but there is a default
+                      ;; candidate only allow selecting when prompt isn't empty
+                      ;; because the default candidate is already selected
+                      ;; anyway.
                       -1)
                      (t 0))
                (1- selectrum--current-candidate-index)))))


### PR DESCRIPTION
Because the default is sorted to the top there is no point in showing it in the prompt (I think it is distracting with selectrums model).

This PR also fixes #67 so that the empty string can be submitted. Also if there is a default value the prompt is only selectable when the input is non empty because if the input is empty the  default value is already selected initially and would be submitted anyway.