### PR TITLE
Improve selectrum-read-library-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,10 +140,11 @@ The format is based on [Keep a Changelog].
 * If `selectrum-num-candidates-displayed` is set to one, the
   highlighting now works correctly. Before, the prompt would get
   highlighted instead of the current candidate. See [#85].
-* `selectrum-read-library-name` showed some entries with `.el`
-  appended which has been fixed. Also `TAB` now inserts the current
-  candidate and not the whole path to the library which isn't a valid
-  input for this command [#73].
+* `selectrum-read-library-name` previously, in certain versions of
+  Emacs, showed some entries with `.el` appended. This has now been
+  fixed. Also, `TAB` now inserts the current candidate and not the
+  whole path to the library, so that the result can be submitted
+  directly ([#73]).
 
 [#4]: https://github.com/raxod502/selectrum/issues/4
 [#12]: https://github.com/raxod502/selectrum/issues/12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,10 @@ The format is based on [Keep a Changelog].
 * If `selectrum-num-candidates-displayed` is set to one, the
   highlighting now works correctly. Before, the prompt would get
   highlighted instead of the current candidate. See [#85].
+* `selectrum-read-library-name` showed some entries with `.el`
+  appended which has been fixed. Also `TAB` now inserts the current
+  candidate and not the whole path to the library which isn't a valid
+  input for this command [#73].
 
 [#4]: https://github.com/raxod502/selectrum/issues/4
 [#12]: https://github.com/raxod502/selectrum/issues/12
@@ -167,6 +171,7 @@ The format is based on [Keep a Changelog].
 [#55]: https://github.com/raxod502/selectrum/issues/55
 [#57]: https://github.com/raxod502/selectrum/pull/57
 [#62]: https://github.com/raxod502/selectrum/pull/62
+[#73]: https://github.com/raxod502/selectrum/pull/73
 [#74]: https://github.com/raxod502/selectrum/pull/74
 [#76]: https://github.com/raxod502/selectrum/pull/76
 [#77]: https://github.com/raxod502/selectrum/pull/77

--- a/selectrum.el
+++ b/selectrum.el
@@ -1424,13 +1424,16 @@ shadows correctly."
                                     (file-name-sans-extension
                                      (selectrum--trailing-components
                                       num-components path)))
-                                   'fixedcase 'literal))
+                                   'fixedcase 'literal
+                                   'selectrum--lib-path path))
                                 paths)))
                    (setq lst (nconc candidate-paths lst)))
                  (cl-return)))
              (cl-incf num-components)))))
      table)
-    (selectrum-read "Library name: " lst :require-match t)))
+    (get-text-property
+     0 'selectrum--lib-path
+     (selectrum-read "Library name: " lst :require-match t))))
 
 (defun selectrum-repeat ()
   "Repeat the last command that used Selectrum, and try to restore state."

--- a/selectrum.el
+++ b/selectrum.el
@@ -1366,15 +1366,14 @@ shadows correctly."
                  (let ((candidate-paths
                         (mapcar (lambda (path)
                                   (propertize
-                                   (file-name-base path)
+                                   (file-name-base
+                                    (file-name-sans-extension path))
                                    'selectrum-candidate-display-prefix
                                    (file-name-directory
                                     (file-name-sans-extension
                                      (selectrum--trailing-components
                                       num-components path)))
-                                   'fixedcase 'literal
-                                   'selectrum-candidate-full
-                                   path))
+                                   'fixedcase 'literal))
                                 paths)))
                    (setq lst (nconc candidate-paths lst)))
                  (cl-return)))


### PR DESCRIPTION
Don't show `.el` suffixes and don't insert whole path on `TAB` as reported by
[oantolin](https://www.reddit.com/user/oantolin) [here](https://www.reddit.com/r/emacs/comments/g6ocid/orderless_a_completion_style_that_matches/foegie3/), requoting below for easy reference:

    (1) some of the candidates ended in .el and some did not (I'm used to none of
     them ending in .el), but much more seriously,

    (2) pressing TAB inserts the full path of the library, which, of course, is not
     the argument find-library takes, so pressing TAB and then RET just produces an
     error message rather than visiting the library file



I'm also working on a proposal of another PR for better implementation of `completing-read-multiple` addressing his IMO valid critique on current implementation.