### PR TITLE
Improve completing-read-multiple (also fixes #80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,11 +53,9 @@ The format is based on [Keep a Changelog].
   automatically by `selectrum-mode`. This means that commands like
   `describe-face` (which delegate to `completing-read-multiple`
   internally) now use Selectrum by default. To select additional
-  candidates within a supported command, use `M-RET`. The feature is
-  supported by a new keyword argument `:multiple` to `selectrum-read`.
-  We have a new face `selectrum-additional-candidate` which determines
-  how selected candidates other than the current candidate are
-  highlighted. See [#53].
+  candidates within a supported command, use `TAB` and input
+  `crm-separator`. The feature is supported by a new keyword argument
+  `:multiple` to `selectrum-read` [#53], [#80], [#74].
 * We provide a `selectrum-completion-in-region` function now and
   install it on `completion-in-region-function` in `selectrum-mode`,
   so `completion-at-point` will use Selectrum when there is more than
@@ -176,6 +174,7 @@ The format is based on [Keep a Changelog].
 [#74]: https://github.com/raxod502/selectrum/pull/74
 [#76]: https://github.com/raxod502/selectrum/pull/76
 [#77]: https://github.com/raxod502/selectrum/pull/77
+[#80]: https://github.com/raxod502/selectrum/issues/80
 [#85]: https://github.com/raxod502/selectrum/pull/85
 [#86]: https://github.com/raxod502/selectrum/pull/86
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ The format is based on [Keep a Changelog].
   `describe-face` (which delegate to `completing-read-multiple`
   internally) now use Selectrum by default. To select additional
   candidates within a supported command, use `TAB` and input
-  `crm-separator` (`,` by default) [#53], [#80], [#74].
+  `crm-separator` (`,` by default). See [#53], [#80], [#74].
 * We provide a `selectrum-completion-in-region` function now and
   install it on `completion-in-region-function` in `selectrum-mode`,
   so `completion-at-point` will use Selectrum when there is more than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,7 @@ The format is based on [Keep a Changelog].
   `describe-face` (which delegate to `completing-read-multiple`
   internally) now use Selectrum by default. To select additional
   candidates within a supported command, use `TAB` and input
-  `crm-separator`. The feature is supported by a new keyword argument
-  `:multiple` to `selectrum-read` [#53], [#80], [#74].
+  `crm-separator`[#53], [#80], [#74].
 * We provide a `selectrum-completion-in-region` function now and
   install it on `completion-in-region-function` in `selectrum-mode`,
   so `completion-at-point` will use Selectrum when there is more than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ The format is based on [Keep a Changelog].
   `describe-face` (which delegate to `completing-read-multiple`
   internally) now use Selectrum by default. To select additional
   candidates within a supported command, use `TAB` and input
-  `crm-separator`[#53], [#80], [#74].
+  `crm-separator` (`,` by default) [#53], [#80], [#74].
 * We provide a `selectrum-completion-in-region` function now and
   install it on `completion-in-region-function` in `selectrum-mode`,
   so `completion-at-point` will use Selectrum when there is more than

--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ how to fix it.
   `kill-ring-save`. When there's an active region in your input, this
   still copies the active region. The behavior of `M-w` is not
   modified when Transient Mark mode is disabled.
-* *To select multiple candidates:* type `M-RET` to select additional
-  candidates before typing `RET` or `C-j` to exit the minibuffer. This
-  is only allowed in commands that use `completing-read-multiple`,
-  such as `describe-face`.
+* *To select multiple candidates:* type `TAB` and input
+  `crm-separator` (`,` by default). This feature only works in
+  commands that use `completing-read-multiple`, such as
+  `describe-face`.
 
 Selectrum respects your custom keybindings, so if you've bound
 `next-line` to `M-*` for some reason, then pressing `M-*` will select
@@ -250,10 +250,6 @@ matching and case-insensitive matching.
 * The currently selected candidate is highlighted with the face
   `selectrum-current-candidate`. If you don't like the color, you can
   adjust it to taste.
-    * When multiple candidates are selected (in commands which allow
-      it, like `describe-face`), the selected candidates other than
-      the current one are highlighted with the face
-      `selectrum-additional-candidate`.
 * By default, the part of each candidate that matches your input is
   highlighted with the face `selectrum-primary-highlight`. There is
   also `selectrum-secondary-highlight`, which is not used by default

--- a/README.md
+++ b/README.md
@@ -571,14 +571,10 @@ Selectrum achieves its conciseness by:
   something else and then just sticking new things onto it every time
   a bug appears
 
-In addition, Selectrum does not support multiple selection or
-alternate actions, unlike Ivy. This is because supporting either of
-these features means you need to throw out the existing
-`completing-read` API, which is an absolutely massive time-sink and
-source of bugs that adds very little to the user experience. Selectrum
-works with *every* Emacs command with approximately no special cases,
-specifically because it focuses on doing the common case as well as
-possible.
+In addition, Selectrum does not support features which break the
+`completing-read` API because and works with *every* Emacs command
+with approximately no special cases, specifically because it focuses
+on doing the common case as well as possible.
 
 As a final note, when you're using `selectrum-prescient.el`, there's
 an easy way to simulate Ivy's alternate actions. Suppose you've typed

--- a/README.md
+++ b/README.md
@@ -139,10 +139,13 @@ how to fix it.
   `kill-ring-save`. When there's an active region in your input, this
   still copies the active region. The behavior of `M-w` is not
   modified when Transient Mark mode is disabled.
-* *To select multiple candidates:* type `TAB` and input
-  `crm-separator` (`,` by default). This feature only works in
+* *To select multiple candidates:* separate them with `crm-separator`
+  (`,` by default). To make this workflow more convenient, you can use
+  `TAB` to complete the currently selected candidate before typing `,`
+  to move on to entering the next one. This feature only works in
   commands that use `completing-read-multiple`, such as
-  `describe-face`.
+  `describe-face`. (If multiple selection is enabled, it is shown in
+  the minibuffer prompt.)
 
 Selectrum respects your custom keybindings, so if you've bound
 `next-line` to `M-*` for some reason, then pressing `M-*` will select

--- a/README.md
+++ b/README.md
@@ -571,10 +571,10 @@ Selectrum achieves its conciseness by:
   something else and then just sticking new things onto it every time
   a bug appears
 
-In addition, Selectrum does not support features which break the
-`completing-read` API because and works with *every* Emacs command
-with approximately no special cases, specifically because it focuses
-on doing the common case as well as possible.
+Selectrum does not support features which break the `completing-read`
+API because and works with *every* Emacs command with approximately no
+special cases, specifically because it focuses on doing the common
+case as well as possible.
 
 As a final note, when you're using `selectrum-prescient.el`, there's
 an easy way to simulate Ivy's alternate actions. Suppose you've typed

--- a/README.md
+++ b/README.md
@@ -572,9 +572,9 @@ Selectrum achieves its conciseness by:
   a bug appears
 
 Selectrum does not support features which break the `completing-read`
-API because and works with *every* Emacs command with approximately no
-special cases, specifically because it focuses on doing the common
-case as well as possible.
+API and works with *every* Emacs command with approximately no special
+cases, specifically because it focuses on doing the common case as
+well as possible.
 
 As a final note, when you're using `selectrum-prescient.el`, there's
 an easy way to simulate Ivy's alternate actions. Suppose you've typed

--- a/selectrum.el
+++ b/selectrum.el
@@ -410,8 +410,8 @@ to be re-filtered.")
 Equivalently, nil if the user is allowed to submit their own
 input that does not match any of the displayed candidates.")
 
-(defvar selectrum--allow-multiple-selection-p nil
-  "Non-nil if multiple selection is allowed.")
+(defvar selectrum--crm-p nil
+  "Non-nil for `selectrum-completing-read-multiple' sessions.")
 
 (defvar selectrum--move-default-candidate-p nil
   "Non-nil means move default candidate to start of list.
@@ -866,7 +866,7 @@ previous selected ones."
    0 (length candidate)
    '(face selectrum-current-candidate) candidate)
   (setq selectrum--result
-        (cond ((and selectrum--allow-multiple-selection-p
+        (cond ((and selectrum--crm-p
                     (string-match crm-separator
                                   selectrum--previous-input-string))
                (with-temp-buffer
@@ -926,7 +926,7 @@ ignores the currently selected candidate, if one exists."
     (let* ((candidate (nth selectrum--current-candidate-index
                            selectrum--refined-candidates))
            (full (selectrum--get-full candidate)))
-      (insert (if (not selectrum--allow-multiple-selection-p)
+      (insert (if (not selectrum--crm-p)
                   full
                 (let ((string ""))
                   (dolist (str (butlast
@@ -1185,7 +1185,7 @@ INHERIT-INPUT-METHOD, see `completing-read-multiple'."
      res
      (minibuffer-with-setup-hook
          (lambda ()
-           (setq-local selectrum--allow-multiple-selection-p t)
+           (setq-local selectrum--crm-p t)
            (let ((inhibit-read-only t))
              (save-excursion
                (goto-char (minibuffer-prompt-end))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1027,7 +1027,8 @@ Otherwise, just eval BODY."
               selectrum--active-p
               selectrum--minibuffer
               selectrum--current-candidate-bounds
-              selectrum--ensure-centered-timer)))
+              selectrum--ensure-centered-timer
+              crm-separator)))
      ;; https://github.com/raxod502/selectrum/issues/39#issuecomment-618350477
      (selectrum--let-maybe
        selectrum--active-p

--- a/selectrum.el
+++ b/selectrum.el
@@ -860,8 +860,8 @@ Or if there is an active region, save the region to kill ring."
 
 (defun selectrum--exit-with (candidate)
   "Exit minibuffer with given CANDIDATE.
-If multiple selection is enabled exit with candidate plus the
-previous selected ones."
+If `selectrum--crm-p' is non-nil exit with the choosen candidates
+plus CANDIDATE."
   (remove-text-properties
    0 (length candidate)
    '(face selectrum-current-candidate) candidate)

--- a/selectrum.el
+++ b/selectrum.el
@@ -780,7 +780,9 @@ into the user input area to start with."
         (when (search-backward ":" nil t)
           (insert
            (apply #'propertize
-                  " [one or more]"
+                  (substitute-command-keys
+                   (concat " [add more using "
+                           "\\[selectrum-insert-current-candidate]]"))
                   (text-properties-at (point))))))))
   (setq selectrum--minibuffer (current-buffer))
   (setq selectrum--start-of-input-marker (point-marker))

--- a/selectrum.el
+++ b/selectrum.el
@@ -875,7 +875,8 @@ Otherwise just return CANDIDATE."
    '(face selectrum-current-candidate) candidate)
   (setq selectrum--result
         (cond ((and selectrum--allow-multiple-selection-p
-                    (string-match crm-separator selectrum--previous-input-string))
+                    (string-match crm-separator
+                                  selectrum--previous-input-string))
                (with-temp-buffer
                  (insert selectrum--previous-input-string)
                  (re-search-backward crm-separator)

--- a/selectrum.el
+++ b/selectrum.el
@@ -874,14 +874,21 @@ Otherwise just return CANDIDATE."
    0 (length candidate)
    '(face selectrum-current-candidate) candidate)
   (setq selectrum--result
-        (if (and selectrum--allow-multiple-selection-p
-                 (string-match crm-separator selectrum--previous-input-string))
-            selectrum--previous-input-string
-          (apply
-           #'run-hook-with-args
-           'selectrum-candidate-selected-hook
-           candidate selectrum--read-args)
-          (selectrum--get-full candidate)))
+        (cond ((and selectrum--allow-multiple-selection-p
+                    (string-match crm-separator selectrum--previous-input-string))
+               (with-temp-buffer
+                 (insert selectrum--previous-input-string)
+                 (re-search-backward crm-separator)
+                 (goto-char (match-end 0))
+                 (delete-region (point) (point-max))
+                 (insert (selectrum--get-full candidate))
+                 (buffer-string)))
+              (t
+               (apply
+                #'run-hook-with-args
+                'selectrum-candidate-selected-hook
+                candidate selectrum--read-args)
+               (selectrum--get-full candidate))))
   (when (string-empty-p selectrum--result)
     (setq selectrum--result (or selectrum--default-candidate "")))
   (let ((inhibit-read-only t))

--- a/selectrum.el
+++ b/selectrum.el
@@ -699,7 +699,8 @@ just rendering it to the screen and then checking."
                        'face 'selectrum-current-candidate displayed-candidate)
                     (add-face-text-property
                      0 (length displayed-candidate)
-                     'selectrum-current-candidate 'append displayed-candidate)))
+                     'selectrum-current-candidate
+                     'append displayed-candidate)))
                 (insert "\n")
                 (when (equal index highlighted-index)
                   (setf (car selectrum--current-candidate-bounds)

--- a/selectrum.el
+++ b/selectrum.el
@@ -776,7 +776,7 @@ into the user input area to start with."
   (when selectrum--allow-multiple-selection-p
     (let ((inhibit-read-only t))
       (save-excursion
-        (minibuffer-prompt-end)
+        (goto-char (minibuffer-prompt-end))
         (when (search-backward ":" nil t)
           (insert
            (apply #'propertize

--- a/selectrum.el
+++ b/selectrum.el
@@ -1211,7 +1211,8 @@ INHERIT-INPUT-METHOD, see `completing-read-multiple'."
                :initial-input initial-input
                :history hist
                :default-candidate def
-               :multiple t)))
+               :multiple t
+               :may-modify-candidates t)))
     (split-string res crm-separator t)))
 
 ;;;###autoload

--- a/selectrum.el
+++ b/selectrum.el
@@ -771,7 +771,7 @@ into the user input area to start with."
           (insert
            (apply #'propertize
                   (substitute-command-keys
-                   (concat " [one OR more using "
+                   (concat " [add more using "
                            "\\[selectrum-insert-current-candidate] "
                            "+ crm-separator]"))
                   (text-properties-at (point))))))))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1045,9 +1045,7 @@ Otherwise, just eval BODY."
               selectrum--active-p
               selectrum--minibuffer
               selectrum--current-candidate-bounds
-              selectrum--ensure-centered-timer
-              crm-separator
-              crm-completion-table)))
+              selectrum--ensure-centered-timer)))
      ;; https://github.com/raxod502/selectrum/issues/39#issuecomment-618350477
      (selectrum--let-maybe
        selectrum--active-p
@@ -1189,6 +1187,7 @@ Replaces `completing-read-multiple'. For PROMPT, TABLE,
 PREDICATE, REQUIRE-MATCH, INITIAL-INPUT, HIST, DEF, and
 INHERIT-INPUT-METHOD, see `completing-read-multiple'."
   (let* ((crm-completion-table table)
+         (crm-separator crm-separator)
          (coll (all-completions "" #'crm--collection-fn predicate))
          (candidates
           (lambda (input)

--- a/selectrum.el
+++ b/selectrum.el
@@ -724,7 +724,7 @@ just rendering it to the screen and then checking."
                                             selectrum-right-margin-padding)))
                       right-margin))
                     (push ol selectrum--right-margin-overlays))))
-               (cl-incf index))
+              (cl-incf index))
             ;; Simplest way to grow the minibuffer to size is to just
             ;; insert some extra newlines :P
             (when selectrum-fix-minibuffer-height

--- a/selectrum.el
+++ b/selectrum.el
@@ -879,8 +879,8 @@ Otherwise just return CANDIDATE."
                                   selectrum--previous-input-string))
                (with-temp-buffer
                  (insert selectrum--previous-input-string)
-                 (re-search-backward crm-separator)
-                 (goto-char (match-end 0))
+                 (goto-char (point-min))
+                 (while (re-search-forward crm-separator nil t))
                  (delete-region (point) (point-max))
                  (insert (selectrum--get-full candidate))
                  (buffer-string)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -781,8 +781,9 @@ into the user input area to start with."
           (insert
            (apply #'propertize
                   (substitute-command-keys
-                   (concat " [add more using "
-                           "\\[selectrum-insert-current-candidate]]"))
+                   (concat " [one OR more using "
+                           "\\[selectrum-insert-current-candidate] "
+                           "+ crm-separator]"))
                   (text-properties-at (point))))))))
   (setq selectrum--minibuffer (current-buffer))
   (setq selectrum--start-of-input-marker (point-marker))

--- a/selectrum.el
+++ b/selectrum.el
@@ -848,9 +848,8 @@ Or if there is an active region, save the region to kill ring."
 
 (defun selectrum--exit-with (candidate)
   "Exit minibuffer with given CANDIDATE.
-If multiple selection is enabled, add CANDIDATE to the list of
-selected candidates and then return the list to `selectrum-read'.
-Otherwise just return CANDIDATE."
+If multiple selection is enabled exit with candidate plus the
+previous selected ones."
   (remove-text-properties
    0 (length candidate)
    '(face selectrum-current-candidate) candidate)

--- a/selectrum.el
+++ b/selectrum.el
@@ -770,10 +770,12 @@ into the user input area to start with."
         (when (search-backward ":" nil t)
           (insert
            (apply #'propertize
-                  (substitute-command-keys
-                   (concat " [add more using "
-                           "\\[selectrum-insert-current-candidate] "
-                           "+ crm-separator]"))
+                  (format " [add more using %s and %s]"
+                          (substitute-command-keys
+                           "\\[selectrum-insert-current-candidate]" )
+                          (if (equal crm-separator "[ \t]*,[ \t]*")
+                              "\",\""
+                            "crm-separator"))
                   (text-properties-at (point))))))))
   (setq selectrum--minibuffer (current-buffer))
   (setq selectrum--start-of-input-marker (point-marker))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1039,7 +1039,8 @@ Otherwise, just eval BODY."
               selectrum--minibuffer
               selectrum--current-candidate-bounds
               selectrum--ensure-centered-timer
-              crm-separator)))
+              crm-separator
+              crm-completion-table)))
      ;; https://github.com/raxod502/selectrum/issues/39#issuecomment-618350477
      (selectrum--let-maybe
        selectrum--active-p

--- a/selectrum.el
+++ b/selectrum.el
@@ -1166,10 +1166,19 @@ INHERIT-INPUT-METHOD, see `completing-read-multiple'."
          (coll (all-completions "" #'crm--collection-fn predicate))
          (candidates
           (lambda (input)
-            (let ((ninput (or (car (last (split-string input crm-separator)))
-                              "")))
-              `((input . ,ninput)
-                (candidates . ,(copy-sequence coll))))))
+            (let ((beg 0)
+                  (inputs ()))
+              (while (string-match crm-separator input beg)
+                (push (substring input beg (match-beginning 0))
+                      inputs)
+                (setq beg (match-end 0)))
+              (let ((coll (cl-delete-if
+                           (lambda (i)
+                             (member i inputs))
+                           (copy-sequence coll)))
+                    (ninput (substring input beg)))
+                `((input . ,ninput)
+                  (candidates . ,coll))))))
          (res (selectrum-read
                prompt
                candidates


### PR DESCRIPTION
This PR implements an alternate replacement for `completing-read-multiple` which mimics the default interface more closely and makes it more convenient for selecting multiple candidates via completion. 

I requote [oantolins](https://www.reddit.com/r/emacs/comments/g6ocid/orderless_a_completion_style_that_matches/foegie3/) critique of the current behaviour here for easier reference:

    - Selecting the first n-1 candidates with M-RET and then the last one with RET
      feels a bit asymmetric. I think I instictively expected that I would select
      all n candidates with M-RET and then RET would confirm the selection without
      adding an extra (n+1)-st candidate.

    - After pressing M-RET the contents of the minibuffer don't change. This has
      positive and negative aspects:

    - 1. On the positive side, the list of candidates doesn't suddenly change, so if
      you wanted to M-RET a couple of other nearby candidates you can easily get to
      them with the arrow keys; on the

    - 2. On the negative side, it makes it pretty inconvenient to use completion! If
      you want to now match some other candidate you often have to delete everything
      you wrote in the minibuffer to do so.

    - You are often flying blind: usually most of your selections aren't visible!
      (Naturally so, if you scroll around the list they can scroll off, if you
      type text to match your next selection your previous ones are unlikely to
      still match.)

    Contrast that last point with the built-in method, where all your selections are
    clearly visible in the minibuffer, separated by commas. It is also very
    convenient to use completion in the built-in method: to add an item, type a
    comma and you can start completing again from scratch!

    All in all it feels like the completing-read-multiple selectrum interface is
    designed for the case of a tiny list of candidates you can scroll around in
    full, not for completion.

I have left the previous multi selection feature untouched because I'm not sure how you want to proceed with this. 

To test the new version call `describe-face` then insert candidates with `TAB` and press `,` to proceed and add more. Finally submit input with `RET`. This way it works exactly like the stock Emacs UI only that it's much better ;)

This new method also has the additional benefits that history for `completing-read-multiple` looks the same as without `selectrum-mode` and you can select history items of previous  multi selections.