### PR TITLE
Fix highlighting for completion-in-region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,9 +127,7 @@ The format is based on [Keep a Changelog].
   trample on the results of `selectrum-highlight-candidates-function`.
   In other words, the matched part of the current candidate is now
   highlighted just like the matched part of the other candidates. See
-  [#21]. Using `add-face-text-property` caused further face trampling
-  issues for Emacs < 27 and was replaced by
-  `font-lock-prepend-text-property` [#76].
+  ([#21], [#76]).
 * Previously, an error was thrown if you used certain non-Selectrum
   minibuffer commands before loading Selectrum. This has been fixed
   ([#28]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,9 @@ The format is based on [Keep a Changelog].
   trample on the results of `selectrum-highlight-candidates-function`.
   In other words, the matched part of the current candidate is now
   highlighted just like the matched part of the other candidates. See
-  [#21].
+  [#21]. Using `add-face-text-property` caused further face trampling
+  issues for Emacs < 27 and was replaced by
+  `font-lock-prepend-text-property` [#76].
 * Previously, an error was thrown if you used certain non-Selectrum
   minibuffer commands before loading Selectrum. This has been fixed
   ([#28]).
@@ -154,6 +156,7 @@ The format is based on [Keep a Changelog].
 [#54]: https://github.com/raxod502/selectrum/pull/54
 [#55]: https://github.com/raxod502/selectrum/issues/55
 [#62]: https://github.com/raxod502/selectrum/pull/62
+[#76]: https://github.com/raxod502/selectrum/pull/76
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/selectrum.el
+++ b/selectrum.el
@@ -539,6 +539,16 @@ just rendering it to the screen and then checking."
                 (run-with-idle-timer
                  0 nil #'selectrum--ensure-current-candidate-centered)))))))
 
+(defun selectrum--minibuffer-pre-command-hook ()
+  "Cleanup highlighting before next command."
+  (when (and selectrum--current-candidate-index
+             (> selectrum--current-candidate-index -1))
+    (let ((cand (nth selectrum--current-candidate-index
+                     selectrum--refined-candidates)))
+      (font-lock--remove-face-from-text-property
+       0 (length cand) 'face 'selectrum-current-candidate
+       cand))))
+
 (defun selectrum--minibuffer-post-command-hook ()
   "Update minibuffer in response to user input."
   (goto-char (max (point) selectrum--start-of-input-marker))
@@ -798,6 +808,8 @@ into the user input area to start with."
             candidates
           (funcall selectrum-preprocess-candidates-function candidates)))
   (setq selectrum--default-candidate default-candidate)
+  (add-hook 'pre-command-hook
+            #'selectrum--minibuffer-pre-command-hook nil 'local)
   ;; Make sure to trigger an "user input changed" event, so that
   ;; candidate refinement happens in `post-command-hook' and an index
   ;; is assigned.

--- a/selectrum.el
+++ b/selectrum.el
@@ -541,13 +541,10 @@ just rendering it to the screen and then checking."
 
 (defun selectrum--minibuffer-pre-command-hook ()
   "Cleanup highlighting before next command."
-  (when (and selectrum--current-candidate-index
-             (> selectrum--current-candidate-index -1))
-    (let ((cand (nth selectrum--current-candidate-index
-                     selectrum--refined-candidates)))
-      (font-lock--remove-face-from-text-property
-       0 (length cand) 'face 'selectrum-current-candidate
-       cand))))
+  (let ((cand (selectrum--get-candidate selectrum--current-candidate-index)))
+    (font-lock--remove-face-from-text-property
+     0 (length cand) 'face 'selectrum-current-candidate
+     cand)))
 
 (defun selectrum--minibuffer-post-command-hook ()
   "Update minibuffer in response to user input."

--- a/selectrum.el
+++ b/selectrum.el
@@ -808,8 +808,9 @@ into the user input area to start with."
             candidates
           (funcall selectrum-preprocess-candidates-function candidates)))
   (setq selectrum--default-candidate default-candidate)
-  (add-hook 'pre-command-hook
-            #'selectrum--minibuffer-pre-command-hook nil 'local)
+  (when (version< emacs-version "27")
+    (add-hook 'pre-command-hook
+              #'selectrum--minibuffer-pre-command-hook nil 'local))
   ;; Make sure to trigger an "user input changed" event, so that
   ;; candidate refinement happens in `post-command-hook' and an index
   ;; is assigned.


### PR DESCRIPTION
When doing `completion-in-region` and input a query and afterwards navigate through the list the `selectrum-current-candidate` highlighting sticks to the parts matched by the query for some reason. I have added a fix which cleans up the current candidate before executing the next command. I don't  understand why it only happens with `completion-in-region`.