### PR TITLE
Fix history commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,13 @@ The format is based on [Keep a Changelog].
   display these indices for your convenience. This feature implements
   similar functionality to `ivy-avy`. See [#16].
 * Recursive minibuffers are now supported.
-* In the standard `completing-read` interface, you can use Isearch to
-  retrieve history elements. The Isearch entry-point bindings now work
-  properly in Selectrum too, except that they allow you to select a
-  history element using Selectrum. See [#49].
+* In the standard `completing-read` interface, you can use
+  `previous-matching-history-element` to retrieve history
+  elements. The binding now works properly in Selectrum too, except
+  that you can use Selectrum to select a history element. See [#49],
+  [#77]. If you prefer to use the original interface you can use
+  `selectrum-previous-history-element` which is just not bound by
+  default [#57].
 * You can now cause the minibuffer to always have the same height,
   even if there are fewer candidates, by enabling
   `selectrum-fix-minibuffer-height` ([#35]).
@@ -153,7 +156,9 @@ The format is based on [Keep a Changelog].
 [#53]: https://github.com/raxod502/selectrum/issues/53
 [#54]: https://github.com/raxod502/selectrum/pull/54
 [#55]: https://github.com/raxod502/selectrum/issues/55
+[#57]: https://github.com/raxod502/selectrum/pull/57
 [#62]: https://github.com/raxod502/selectrum/pull/62
+[#77]: https://github.com/raxod502/selectrum/pull/77
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1545,7 +1545,10 @@ ARGS are standard as in all `:around' advice."
           ;; No sharp quote because `set-minibuffer-message' is not
           ;; defined in older Emacs versions.
           (advice-add 'set-minibuffer-message :after
-                      #'selectrum--fix-set-minibuffer-message))
+                      #'selectrum--fix-set-minibuffer-message)
+          (define-key minibuffer-local-map
+            [remap previous-matching-history-element]
+            'selectrum-select-from-history))
       (when (equal (default-value 'completing-read-function)
                    #'selectrum-completing-read)
         (setq-default completing-read-function
@@ -1576,7 +1579,10 @@ ARGS are standard as in all `:around' advice."
       ;; No sharp quote because `set-minibuffer-message' is not
       ;; defined in older Emacs versions.
       (advice-remove 'set-minibuffer-message
-                     #'selectrum--fix-set-minibuffer-message))))
+                     #'selectrum--fix-set-minibuffer-message)
+      (define-key minibuffer-local-map
+        [remap previous-matching-history-element]
+        nil))))
 
 ;;;; Closing remarks
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -189,15 +189,11 @@ strings."
     ([remap end-of-buffer]                    . selectrum-goto-end)
     ([remap kill-ring-save]                   . selectrum-kill-ring-save)
     ([remap previous-matching-history-element]
-     . selectrum-previous-matching-history-element)
+     . selectrum-select-from-history)
     ([remap previous-history-element]
      . selectrum-previous-history-element)
     ([remap next-history-element]
      . selectrum-next-history-element)
-    ("C-s"                                    . selectrum-select-from-history)
-    ("C-r"                                    . selectrum-select-from-history)
-    ("C-M-s"                                  . selectrum-select-from-history)
-    ("C-M-r"                                  . selectrum-select-from-history)
     ("C-j"                                    . selectrum-submit-exact-input)
     ("M-RET"                                  . selectrum-select-additional)
     ("TAB"

--- a/selectrum.el
+++ b/selectrum.el
@@ -1580,9 +1580,11 @@ ARGS are standard as in all `:around' advice."
       ;; defined in older Emacs versions.
       (advice-remove 'set-minibuffer-message
                      #'selectrum--fix-set-minibuffer-message)
-      (define-key minibuffer-local-map
-        [remap previous-matching-history-element]
-        nil))))
+      (when (eq (lookup-key minibuffer-local-map
+                            [remap previous-matching-history-element])
+                'selectrum-select-from-history)
+        (define-key minibuffer-local-map
+          [remap previous-matching-history-element] nil)))))
 
 ;;;; Closing remarks
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -960,7 +960,9 @@ ignores the currently selected candidate, if one exists."
   "Forward to `previous-matching-history-element'."
   (interactive)
   (let ((inhibit-read-only t))
-    (call-interactively 'previous-matching-history-element)
+    (save-restriction
+      (narrow-to-region (point-min) selectrum--end-of-input-marker)
+      (call-interactively 'previous-matching-history-element))
     (goto-char (minibuffer-prompt-end))))
 
 (defun selectrum-next-history-element (arg)
@@ -968,7 +970,9 @@ ignores the currently selected candidate, if one exists."
 ARG has same meaning as in `next-history-element'."
   (interactive "p")
   (let ((inhibit-read-only t))
-    (next-history-element arg)
+    (save-restriction
+      (narrow-to-region (point-min) selectrum--end-of-input-marker)
+      (next-history-element arg))
     (goto-char (minibuffer-prompt-end))))
 
 (defun selectrum-previous-history-element (arg)
@@ -976,7 +980,9 @@ ARG has same meaning as in `next-history-element'."
 ARG has same meaning as in `previous-history-element'."
   (interactive "p")
   (let ((inhibit-read-only t))
-    (previous-history-element arg)
+    (save-restriction
+      (narrow-to-region (point-min) selectrum--end-of-input-marker)
+      (previous-history-element arg))
     (goto-char (minibuffer-prompt-end))))
 
 (defun selectrum-select-from-history ()

--- a/selectrum.el
+++ b/selectrum.el
@@ -1582,7 +1582,7 @@ ARGS are standard as in all `:around' advice."
                      #'selectrum--fix-set-minibuffer-message)
       (when (eq (lookup-key minibuffer-local-map
                             [remap previous-matching-history-element])
-                'selectrum-select-from-history)
+                #'selectrum-select-from-history)
         (define-key minibuffer-local-map
           [remap previous-matching-history-element] nil)))))
 


### PR DESCRIPTION
History again :sweat_smile: 

I removed the narrowing at some point because I though it's not necessary and did not remember why I added it. Just discovered it's needed because history saves the minibuffer contents when you start navigation history backwards and inserts it back when you navigate forward. So if you do `M-p` and then `M-n` your input is defined by the whole contents from before and when you afterwards type something nothing happens because this breaks everything.