### PR TITLE
Utilize completion metadata and exit-function in completion-in-region-function

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -1224,8 +1224,7 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
       (let ((status
              (cond
               ((not (member result cands)) 'sole)
-              ((eq (try-completion result collection predicate) t) 'finished)
-              (t 'exact))))
+              (t 'finished))))
         (funcall exit-func result status)))))
 
 (defvar selectrum--old-completion-in-region-function nil

--- a/selectrum.el
+++ b/selectrum.el
@@ -1187,6 +1187,8 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                                      :annotation-function))
          (docsig-func (plist-get completion-extra-properties
                                  :company-docsig))
+         (exit-func (plist-get completion-extra-properties
+                               :exit-function))
          (display-sort-func (cdr (assq 'display-sort-function meta)))
          (cands (selectrum--map-destructive
                  (lambda (cand)
@@ -1217,7 +1219,14 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
       ( _ (setq result (selectrum-read "Completion: " cands))))
     (when result
       (delete-region start end)
-      (insert (substring-no-properties result)))))
+      (insert (substring-no-properties result)))
+    (when exit-func
+      (let ((status
+             (cond
+              ((not (member result cands)) 'sole)
+              ((eq (try-completion result collection predicate) t) 'finished)
+              (t 'exact))))
+        (funcall exit-func result status)))))
 
 (defvar selectrum--old-completion-in-region-function nil
   "Previous value of `completion-in-region-function'.")

--- a/selectrum.el
+++ b/selectrum.el
@@ -1177,17 +1177,20 @@ INHERIT-INPUT-METHOD, see `completing-read-multiple'."
   "Complete in-buffer text using a list of candidates.
 Can be used as `completion-in-region-function'. For START, END,
 COLLECTION, and PREDICATE, see `completion-in-region'."
-  (let* ((cands (nconc
-                 (completion-all-completions
-                  (buffer-substring-no-properties start end)
-                  collection
-                  predicate
-                  (- end start))
+  (let* ((input (buffer-substring-no-properties start end))
+         (meta (completion-metadata input collection predicate))
+         (cands (nconc
+                 (completion-all-completions input collection predicate
+                                             (- end start) meta)
                  nil))
          (annotation-func (plist-get completion-extra-properties
                                      :annotation-function))
          (docsig-func (plist-get completion-extra-properties
                                  :company-docsig))
+         (selectrum-preprocess-candidates-function
+          (if-let (display-sort-func (cdr (assq 'display-sort-function meta)))
+              display-sort-func
+            selectrum-preprocess-candidates-function))
          (cands (selectrum--map-destructive
                  (lambda (cand)
                    (propertize

--- a/selectrum.el
+++ b/selectrum.el
@@ -1187,10 +1187,7 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                                      :annotation-function))
          (docsig-func (plist-get completion-extra-properties
                                  :company-docsig))
-         (selectrum-preprocess-candidates-function
-          (if-let (display-sort-func (cdr (assq 'display-sort-function meta)))
-              display-sort-func
-            selectrum-preprocess-candidates-function))
+         (display-sort-func (cdr (assq 'display-sort-function meta)))
          (cands (selectrum--map-destructive
                  (lambda (cand)
                    (propertize
@@ -1209,7 +1206,11 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                          (format "%s" docsig)
                          'face 'selectrum-completion-annotation)))))
                  cands))
+         (selectrum-should-sort-p selectrum-should-sort-p)
          (result nil))
+    (when display-sort-func
+      (setq cands (funcall display-sort-func cands))
+      (setq selectrum-should-sort-p nil))
     (pcase (length cands)
       (`0 (message "No match"))
       (`1 (setq result (car cands)))


### PR DESCRIPTION
When the collection is a function, it can return "completion metadata". It can specify how to sort the candidates, which we should handle.

Simple test:

``` elisp
(defun my-collection (string pred flag)
  (pcase flag
    ('metadata `(metadata (display-sort-function . ,#'identity)))
    (t '("aaa" "aa" "a"))
    (_ (error "FLAG is not handled"))))

(selectrum-completion-in-region (point) (point) #'my-collection nil)
```

With this patch, you'll see Selectrum puts "aaa" first, than "aa", than "a", which is expected. If you delete the `metadata` line in `my-collection`, Selectrum sorts the candidates based on their lengths, as it should.

The completion metadata has 4 keys:

- `category`: used for overriding `completion-styles` and `completion-cycle-threshold`, which is not relevant to us.
- `annotation-function`: we already handle it.
- `display-sort-function`: we handle it by this patch.
- `cycle-sort-function`: used for the "cycling" UI, i.e., it shows one candidate at a time in the buffer, then you could cycle between candidates, which is not relevant to us.

So I can say we've done our business with completion metadata.