### PR TITLE
Fix highlighting for one candidate display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ The format is based on [Keep a Changelog].
 * Previously, an error was thrown if you used certain non-Selectrum
   minibuffer commands before loading Selectrum. This has been fixed
   ([#28]).
+* If `selectrum-num-candidates-displayed` is set to one, the
+  highlighting works correctly now [#85]. Before the prompt would get
+  highlighted instead of the current candidate.
 
 [#4]: https://github.com/raxod502/selectrum/issues/4
 [#12]: https://github.com/raxod502/selectrum/issues/12
@@ -159,6 +162,7 @@ The format is based on [Keep a Changelog].
 [#57]: https://github.com/raxod502/selectrum/pull/57
 [#62]: https://github.com/raxod502/selectrum/pull/62
 [#77]: https://github.com/raxod502/selectrum/pull/77
+[#85]: https://github.com/raxod502/selectrum/pull/85
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,8 +132,8 @@ The format is based on [Keep a Changelog].
   minibuffer commands before loading Selectrum. This has been fixed
   ([#28]).
 * If `selectrum-num-candidates-displayed` is set to one, the
-  highlighting works correctly now [#85]. Before the prompt would get
-  highlighted instead of the current candidate.
+  highlighting now works correctly. Before, the prompt would get
+  highlighted instead of the current candidate. See [#85].
 
 [#4]: https://github.com/raxod502/selectrum/issues/4
 [#12]: https://github.com/raxod502/selectrum/issues/12

--- a/selectrum.el
+++ b/selectrum.el
@@ -612,7 +612,7 @@ just rendering it to the screen and then checking."
                   ;; there are guaranteed to be more candidates shown
                   ;; below the selection than above.
                   (1+ (- selectrum--current-candidate-index
-                         (/ selectrum-num-candidates-displayed 2)))
+                         (max 1 (/ selectrum-num-candidates-displayed 2))))
                   0
                   (max (- (length selectrum--refined-candidates)
                           selectrum-num-candidates-displayed)


### PR DESCRIPTION
If `selectrum-num-candidates-displayed` is set to one the prompt gets highlighted instead of the candidate.