### PR TITLE
Inherit from built-in completions faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,10 @@ The format is based on [Keep a Changelog].
   so `completion-at-point` will use Selectrum when there is more than
   one completion ([#42]). This function can display annotation
   informations if the `completion-at-point-function` backend offers
-  them, and they use the face `selectrum-completion-annotation`
-  ([#62]).
+  them ([#62]).
+* This function uses the faces `selectrum-completion-annotation` and
+  `selectrum-completion-docsig`, and is affected by the built-in face
+  `completions-common-part` ([#86]).
 
 ### Enhancements
 * `selectrum-read-file-name` which is used as
@@ -160,6 +162,7 @@ The format is based on [Keep a Changelog].
 [#62]: https://github.com/raxod502/selectrum/pull/62
 [#76]: https://github.com/raxod502/selectrum/pull/76
 [#77]: https://github.com/raxod502/selectrum/pull/77
+[#86]: https://github.com/raxod502/selectrum/pull/86
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,10 +63,9 @@ The format is based on [Keep a Changelog].
   so `completion-at-point` will use Selectrum when there is more than
   one completion ([#42]). This function can display annotation
   informations if the `completion-at-point-function` backend offers
-  them ([#62]).
-* This function uses the faces `selectrum-completion-annotation` and
-  `selectrum-completion-docsig`, and is affected by the built-in face
-  `completions-common-part` ([#86]).
+  them ([#62]). Appearance can be configured using the faces
+  `selectrum-completion-annotation`, `selectrum-completion-docsig`,
+  and `completions-common-part` ([#86]).
 
 ### Enhancements
 * `selectrum-read-file-name` which is used as

--- a/README.md
+++ b/README.md
@@ -269,6 +269,11 @@ matching and case-insensitive matching.
 * The `selectrum-completion-in-region` function can display annotations
   if the `completion-in-region-function` backend offers them. Customize
   the face `selectrum-completion-annotation` to change their appearance.
+* It can also display signatures if offered. Customize the face
+  `selectrum-completion-docsig` to change their appearance.
+* Finally, customize the built-in face `completions-common-part` for the
+  common part of the completion candidates.
+
 
 As an example of customizing the faces, I use the
 [Zerodark](https://github.com/NicolasPetton/zerodark-theme) color

--- a/README.md
+++ b/README.md
@@ -268,12 +268,14 @@ matching and case-insensitive matching.
   candidate.
 * The `selectrum-completion-in-region` function can display annotations
   if the `completion-in-region-function` backend offers them. Customize
-  the face `selectrum-completion-annotation` to change their appearance.
-* It can also display signatures if offered. Customize the face
-  `selectrum-completion-docsig` to change their appearance.
-* Finally, customize the built-in face `completions-common-part` for the
-  common part of the completion candidates.
-
+  the face `selectrum-completion-annotation` to change their
+  appearance.
+    * Customize the face `selectrum-completion-docsig` to change the
+      appearance of function signatures show by
+      `completion-in-region`.
+    * Customize the face `completions-common-part` to change the
+      appearance of the common prefix in `completion-in-region`
+      candidates.
 
 As an example of customizing the faces, I use the
 [Zerodark](https://github.com/NicolasPetton/zerodark-theme) color

--- a/selectrum.el
+++ b/selectrum.el
@@ -68,8 +68,13 @@ parts of the input."
   :group 'selectrum-faces)
 
 (defface selectrum-completion-annotation
-  '((t :inherit italic :foreground "#888888"))
+  '((t :inherit completions-annotations))
   "Face used to display annotations in `selectrum-completion-in-region'."
+  :group 'selectrum-faces)
+
+(defface selectrum-completion-docsig
+  '((t :inherit selectrum-completion-annotation :slant italic))
+  "Face used to display docsigs in `selectrum-completion-in-region'."
   :group 'selectrum-faces)
 
 ;;;; Variables
@@ -1206,7 +1211,7 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                       (when-let ((docsig (funcall docsig-func cand)))
                         (propertize
                          (format "%s" docsig)
-                         'face 'selectrum-completion-annotation)))))
+                         'face 'selectrum-completion-docsig)))))
                  cands))
          (result nil))
     (pcase (length cands)


### PR DESCRIPTION
Emacs already has the default faces `completions-annotations` and
`completions-common-part`, the latter of which we were already using
because we queried for completion candidates.

The former face we should inherit from instead of choosing our own color
for `selectrum-completion-annotation`. This increases the chances that
`selectrum-completion-in-region` will look as it should out-of-the-box,
as users' themes are more likely to have customized the built-in faces
than a new face.

We also add the face `selectrum-completion-docsig`, which inherits from
`selectrum-completion-annotation` and is italicized. Because we
distinguish between these two types of information, we provide our own
pair of faces for customization instead of making both use the single
built-in face `completions-annotations`.