### PR TITLE
Respect completion boundaries in completion-in-region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,8 @@ The format is based on [Keep a Changelog].
   so `completion-at-point` will use Selectrum when there is more than
   one completion ([#42]). This function can display annotation
   informations if the `completion-at-point-function` backend offers
-  them ([#62]). Appearance can be configured using the faces
+  them ([#62]), and will respect completion boundaries ([#89]).
+  Appearance can be configured using the faces
   `selectrum-completion-annotation`, `selectrum-completion-docsig`,
   and `completions-common-part` ([#86]).
 
@@ -178,6 +179,7 @@ The format is based on [Keep a Changelog].
 [#77]: https://github.com/raxod502/selectrum/pull/77
 [#85]: https://github.com/raxod502/selectrum/pull/85
 [#86]: https://github.com/raxod502/selectrum/pull/86
+[#89]: https://github.com/raxod502/selectrum/pull/89
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1218,67 +1218,69 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
   (let* ((input (buffer-substring-no-properties start end))
          (meta (completion-metadata input collection predicate))
          (category (cdr (assq 'category meta)))
+         (bound (pcase category
+                  ('file start)
+                  (_ (+ start (car (completion-boundaries
+                                    input collection predicate ""))))))
          (exit-func (plist-get completion-extra-properties
                                :exit-function))
+         (cands (nconc
+                 (completion-all-completions input collection predicate
+                                             (- end start) meta)
+                 nil))
          (exit-status nil)
          (result nil))
-    (pcase category
-      ('file (setq result (selectrum--completing-read-file-name
-                           "Completion: " collection predicate
-                           nil input))
-             (setq exit-status 'finished))
-      (_
-       (let* ((cands (nconc
-                      (completion-all-completions input collection predicate
-                                                  (- end start) meta)
-                      nil))
-              (annotation-func (plist-get completion-extra-properties
-                                          :annotation-function))
-              (docsig-func (plist-get completion-extra-properties
-                                      :company-docsig))
-              (display-sort-func (cdr (assq 'display-sort-function meta)))
-              (cands (selectrum--map-destructive
-                      (lambda (cand)
-                        (propertize
-                         cand
-                         'selectrum-candidate-display-suffix
-                         (when annotation-func
-                           ;; Rule out situations where the annotation
-                           ;; is nil.
-                           (when-let ((annotation
-                                       (funcall annotation-func cand)))
-                             (propertize
-                              annotation
-                              'face 'selectrum-completion-annotation)))
-                         'selectrum-candidate-display-right-margin
-                         (when docsig-func
-                           (when-let ((docsig (funcall docsig-func cand)))
-                             (propertize
-                              (format "%s" docsig)
-                              'face 'selectrum-completion-docsig)))))
-                      cands))
-              (selectrum-should-sort-p selectrum-should-sort-p))
-         (when display-sort-func
-           (setq cands (funcall display-sort-func cands))
-           (setq selectrum-should-sort-p nil))
-         (pcase (length cands)
-           (`0 (message "No match"))
-           (`1 (setq result (car cands)))
-           ( _ (setq result (selectrum-read
-                             "Completion: " cands :may-modify-candidates t))))
-         (setq exit-status
-               (cond ((not (member result cands)) 'sole)
-                     (t 'finished))))))
-    (when result
-      (let* ((bound (car (completion-boundaries
-                          input collection predicate "")))
-             (start (pcase category
-                      ('file start)
-                      (_ (+ start bound)))))
-        (delete-region start end)
-        (insert (substring-no-properties result))))
-    (when exit-func
-      (funcall exit-func result exit-status))))
+    (if (null cands)
+        (progn (unless completion-fail-discreetly (ding))
+               (message "No match"))
+      (pcase category
+        ('file (setq result (selectrum--completing-read-file-name
+                             "Completion: " collection predicate
+                             nil input))
+               (setq exit-status 'finished))
+        (_
+         (let* ((annotation-func (plist-get completion-extra-properties
+                                            :annotation-function))
+                (docsig-func (plist-get completion-extra-properties
+                                        :company-docsig))
+                (display-sort-func (cdr (assq 'display-sort-function meta)))
+                (cands (selectrum--map-destructive
+                        (lambda (cand)
+                          (propertize
+                           cand
+                           'selectrum-candidate-display-suffix
+                           (when annotation-func
+                             ;; Rule out situations where the annotation
+                             ;; is nil.
+                             (when-let ((annotation
+                                         (funcall annotation-func cand)))
+                               (propertize
+                                annotation
+                                'face 'selectrum-completion-annotation)))
+                           'selectrum-candidate-display-right-margin
+                           (when docsig-func
+                             (when-let ((docsig (funcall docsig-func cand)))
+                               (propertize
+                                (format "%s" docsig)
+                                'face 'selectrum-completion-docsig)))))
+                        cands))
+                (selectrum-should-sort-p selectrum-should-sort-p))
+           (when display-sort-func
+             (setq cands (funcall display-sort-func cands))
+             (setq selectrum-should-sort-p nil))
+           (pcase (length cands)
+             ;; We already rule out the situation where `cands' is empty.
+             (`1 (setq result (car cands)))
+             ( _ (setq result (selectrum-read
+                               "Completion: " cands
+                               :may-modify-candidates t))))
+           (setq exit-status
+                 (cond ((not (member result cands)) 'sole)
+                       (t 'finished))))))
+      (delete-region bound end)
+      (insert (substring-no-properties result))
+      (when exit-func
+        (funcall exit-func result exit-status)))))
 
 (defvar selectrum--old-completion-in-region-function nil
   "Previous value of `completion-in-region-function'.")

--- a/selectrum.el
+++ b/selectrum.el
@@ -1217,56 +1217,68 @@ Can be used as `completion-in-region-function'. For START, END,
 COLLECTION, and PREDICATE, see `completion-in-region'."
   (let* ((input (buffer-substring-no-properties start end))
          (meta (completion-metadata input collection predicate))
-         (cands (nconc
-                 (completion-all-completions input collection predicate
-                                             (- end start) meta)
-                 nil))
-         (annotation-func (plist-get completion-extra-properties
-                                     :annotation-function))
-         (docsig-func (plist-get completion-extra-properties
-                                 :company-docsig))
+         (category (cdr (assq 'category meta)))
          (exit-func (plist-get completion-extra-properties
                                :exit-function))
-         (display-sort-func (cdr (assq 'display-sort-function meta)))
-         (cands (selectrum--map-destructive
-                 (lambda (cand)
-                   (propertize
-                    cand
-                    'selectrum-candidate-display-suffix
-                    (when annotation-func
-                      ;; Rule out situations where the annotation is nil.
-                      (when-let ((annotation (funcall annotation-func cand)))
-                        (propertize
-                         annotation
-                         'face 'selectrum-completion-annotation)))
-                    'selectrum-candidate-display-right-margin
-                    (when docsig-func
-                      (when-let ((docsig (funcall docsig-func cand)))
-                        (propertize
-                         (format "%s" docsig)
-                         'face 'selectrum-completion-docsig)))))
-                 cands))
-         (selectrum-should-sort-p selectrum-should-sort-p)
+         (exit-status nil)
          (result nil))
-    (when display-sort-func
-      (setq cands (funcall display-sort-func cands))
-      (setq selectrum-should-sort-p nil))
-    (pcase (length cands)
-      (`0 (message "No match"))
-      (`1 (setq result (car cands)))
-      ( _ (setq result (selectrum-read
-                        "Completion: " cands :may-modify-candidates t))))
+    (pcase category
+      ('file (setq result (selectrum--completing-read-file-name
+                           "Completion: " collection predicate
+                           nil input))
+             (setq exit-status 'finished))
+      (_
+       (let* ((cands (nconc
+                      (completion-all-completions input collection predicate
+                                                  (- end start) meta)
+                      nil))
+              (annotation-func (plist-get completion-extra-properties
+                                          :annotation-function))
+              (docsig-func (plist-get completion-extra-properties
+                                      :company-docsig))
+              (display-sort-func (cdr (assq 'display-sort-function meta)))
+              (cands (selectrum--map-destructive
+                      (lambda (cand)
+                        (propertize
+                         cand
+                         'selectrum-candidate-display-suffix
+                         (when annotation-func
+                           ;; Rule out situations where the annotation
+                           ;; is nil.
+                           (when-let ((annotation
+                                       (funcall annotation-func cand)))
+                             (propertize
+                              annotation
+                              'face 'selectrum-completion-annotation)))
+                         'selectrum-candidate-display-right-margin
+                         (when docsig-func
+                           (when-let ((docsig (funcall docsig-func cand)))
+                             (propertize
+                              (format "%s" docsig)
+                              'face 'selectrum-completion-docsig)))))
+                      cands))
+              (selectrum-should-sort-p selectrum-should-sort-p))
+         (when display-sort-func
+           (setq cands (funcall display-sort-func cands))
+           (setq selectrum-should-sort-p nil))
+         (pcase (length cands)
+           (`0 (message "No match"))
+           (`1 (setq result (car cands)))
+           ( _ (setq result (selectrum-read
+                             "Completion: " cands :may-modify-candidates t))))
+         (setq exit-status
+               (cond ((not (member result cands)) 'sole)
+                     (t 'finished))))))
     (when result
-      (let ((bound (car (completion-boundaries
-                         input collection predicate ""))))
-        (delete-region (+ start bound) end)
+      (let* ((bound (car (completion-boundaries
+                          input collection predicate "")))
+             (start (pcase category
+                      ('file start)
+                      (_ (+ start bound)))))
+        (delete-region start end)
         (insert (substring-no-properties result))))
     (when exit-func
-      (let ((status
-             (cond
-              ((not (member result cands)) 'sole)
-              (t 'finished))))
-        (funcall exit-func result status)))))
+      (funcall exit-func result exit-status))))
 
 (defvar selectrum--old-completion-in-region-function nil
   "Previous value of `completion-in-region-function'.")

--- a/selectrum.el
+++ b/selectrum.el
@@ -1257,8 +1257,10 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
       ( _ (setq result (selectrum-read
                         "Completion: " cands :may-modify-candidates t))))
     (when result
-      (delete-region start end)
-      (insert (substring-no-properties result)))
+      (let ((bound (car (completion-boundaries
+                         input collection predicate ""))))
+        (delete-region (+ start bound) end)
+        (insert (substring-no-properties result))))
     (when exit-func
       (let ((status
              (cond


### PR DESCRIPTION
Simple test:

- `M-x shell`
- Type `cd /some/path`
- Call `completion-in-region`
- The path is expanded correctly. In previous versions, `/some/path` will be deleted.

@clemera offerd a lot of help and suggestions in https://github.com/raxod502/selectrum/pull/84 (Thanks!). I'd like to explain some of my decisions, and discuss on those I'm not sure about.

- @clemera suggested using `choose-completion-string`. It actually doesn't fix the bug. I looked into it, it uses `completion-boundaries` on `minibuffer-completion-table` and `minibuffer-completion-predicate`, but even I let bind those variables, it doesn't work. So I fixed it by directly using `completion-boundaries`.

  Also, based on the code of `simple.el`, seems `choose-completion-string` is used when choose a candidate in the `*Completion*` buffer.

- We mentioned `base-size`. I found the relevant docstrings: see `completion-base-size` and `completion-base-position`. From the docstrings, they are used only for the `*Completion*` buffer (should be some face related things), plus handling it doesn't fix the bug. So I didn't use it.

- @clemera suggested using `completion--done` to do the things after completion (e.g. calling `exit-function`). I didn't use it, but I don't oppose it. From the code, seems it deals with some message relevant things, which I don't understand well for now.

- @clemera suggested always using the `exact` status in `exit-function`, since it "leads to less problems". When completing the path in `shell-mode`, with this patch, sometimes a space is inserted after completion, and sometimes doesn't. And with the default UI, it never inserts the space. I don't oppose this change, but I feel the reason is insufficient.

When hacking this, my feeling is it seems Emacs strongly assumes the `*Completion*` buffer is the only UI to use, so relevant code is everywhere and in every abstraction level, which contradicts the pluggable `completion-in-region-function` design. Due to this reason, I would like to avoid using these built-in functions in `selectrum-completion-in-region`.