### PR TITLE
Handle minibuffer completion table, predicate and metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ The format is based on [Keep a Changelog].
   `annotation-function` or `display-sort-function` in its metadata,
   Selectrum will use this information to annotate or sort the
   candidates accordingly ([#82], [#95]).
-* One can trigger an update of Selectrums completions UI manually by
+* One can trigger an update of Selectrum's completions UI manually by
   calling `selectrum-exhibit` ([#95]).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,11 +69,11 @@ The format is based on [Keep a Changelog].
   `minibuffer-completion-predicate`. These can be used to pass the
   `completing-read` collection and predicate so they are available for
   internal handling of completion API features and for other external
-  commands or packages which make use of them ([#94]).
+  commands or packages which make use of them ([#94], [#95]).
 * If the completion table passed to `completing-read` provides
   `annotation-function` or `display-sort-function` in its metadata,
   Selectrum will use this information to annotate or sort the
-  candidates accordingly ([#95]).
+  candidates accordingly ([#82], [#95]).
 * One can trigger an update of Selectrums completions UI manually by
   calling `selectrum-exhibit` ([#95]).
 
@@ -188,6 +188,7 @@ The format is based on [Keep a Changelog].
 [#76]: https://github.com/raxod502/selectrum/pull/76
 [#77]: https://github.com/raxod502/selectrum/pull/77
 [#80]: https://github.com/raxod502/selectrum/issues/80
+[#82]: https://github.com/raxod502/selectrum/issues/82
 [#85]: https://github.com/raxod502/selectrum/pull/85
 [#86]: https://github.com/raxod502/selectrum/pull/86
 [#89]: https://github.com/raxod502/selectrum/pull/89

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,11 @@ The format is based on [Keep a Changelog].
   `minibuffer-completion-predicate`. These can be used to pass the
   `completing-read` collection and predicate so they are available for
   internal handling of completion API features and for other external
-  commands or packages which make use of them.
+  commands or packages which make use of them ([#94]).
+* If the completion table passed to `completing-read` provides
+  `annotation-function` or `display-sort-function` in its metadata,
+  Selectrum will use this information to annotate or sort the
+  candidates accordingly ([#95]).
 
 
 ### Enhancements
@@ -185,6 +189,8 @@ The format is based on [Keep a Changelog].
 [#85]: https://github.com/raxod502/selectrum/pull/85
 [#86]: https://github.com/raxod502/selectrum/pull/86
 [#89]: https://github.com/raxod502/selectrum/pull/89
+[#94]: https://github.com/raxod502/selectrum/issues/94
+[#95]: https://github.com/raxod502/selectrum/pull/95
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@ The format is based on [Keep a Changelog].
   Appearance can be configured using the faces
   `selectrum-completion-annotation`, `selectrum-completion-docsig`,
   and `completions-common-part` ([#86]).
+* `selectrum-read` accepts two additional keyword arguments
+  `minibuffer-completion-table` and
+  `minibuffer-completion-predicate`. These can be used to pass the
+  `completing-read` collection and predicate so they are available for
+  internal handling of completion API features and for other external
+  commands or packages which make use of them.
+
 
 ### Enhancements
 * `selectrum-read-file-name` which is used as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ The format is based on [Keep a Changelog].
   `annotation-function` or `display-sort-function` in its metadata,
   Selectrum will use this information to annotate or sort the
   candidates accordingly ([#95]).
+* One can trigger an update of Selectrums completions UI manually by
+  calling `selectrum-exhibit` ([#95]).
 
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,8 @@ The format is based on [Keep a Changelog].
 * If the completion table passed to `completing-read` provides
   `annotation-function` or `display-sort-function` in its metadata,
   Selectrum will use this information to annotate or sort the
-  candidates accordingly ([#82], [#95]).
+  candidates accordingly. Annotations defined by
+  `completion-extra-properties` are handled, too ([#82], [#95]).
 * One can trigger an update of Selectrum's completions UI manually by
   calling `selectrum-exhibit` ([#95]).
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -357,6 +357,29 @@ If PREDICATE is non-nil, then it filters the collection as in
   (or (get-text-property 0 'selectrum-candidate-full candidate)
       candidate))
 
+(defun selectrum--get-annotation-suffix (string annotation-func)
+  "Get `selectrum-candidate-display-suffix' value for annotation.
+
+Used to display STRING according to ANNOTATION-FUNC from
+metadata."
+  (when annotation-func
+    ;; Rule out situations where the annotation
+    ;; is nil.
+    (when-let ((annotation (funcall annotation-func string)))
+      (propertize
+       annotation
+       'face 'selectrum-completion-annotation))))
+
+(defun selectrum--get-margin-docsig (string docsig-func)
+  "Get `selectrum-candidate-display-right-margin' value for docsig.
+
+Used to display STRING according to DOCSIG-FUNC from metadata."
+  (when docsig-func
+    (when-let ((docsig (funcall docsig-func string)))
+      (propertize
+       (format "%s" docsig)
+       'face 'selectrum-completion-docsig))))
+
 ;;;; Minibuffer state
 
 (defvar selectrum--start-of-input-marker nil
@@ -1286,20 +1309,11 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                           (propertize
                            cand
                            'selectrum-candidate-display-suffix
-                           (when annotation-func
-                             ;; Rule out situations where the annotation
-                             ;; is nil.
-                             (when-let ((annotation
-                                         (funcall annotation-func cand)))
-                               (propertize
-                                annotation
-                                'face 'selectrum-completion-annotation)))
+                           (selectrum--get-annotation-suffix
+                            cand annotation-func)
                            'selectrum-candidate-display-right-margin
-                           (when docsig-func
-                             (when-let ((docsig (funcall docsig-func cand)))
-                               (propertize
-                                (format "%s" docsig)
-                                'face 'selectrum-completion-docsig)))))
+                           (selectrum--get-margin-docsig
+                            cand docsig-func)))
                         cands))
                 (selectrum-should-sort-p selectrum-should-sort-p))
            (when display-sort-func

--- a/selectrum.el
+++ b/selectrum.el
@@ -568,17 +568,28 @@ just rendering it to the screen and then checking."
   "Initialize candidates from `minibuffer-completion-table'."
   (when (and (not selectrum--preprocessed-candidates)
              minibuffer-completion-table)
-    (let ((sortf (completion-metadata-get
-                  (completion-metadata
+    (let* ((metad (completion-metadata
                    (selectrum--current-input)
                    minibuffer-completion-table
-                   minibuffer-completion-predicate)
-                  'display-sort-function)))
+                   minibuffer-completion-predicate))
+           (sortf (completion-metadata-get
+                   metad
+                   'display-sort-function))
+           (annotf (completion-metadata-get
+                    metad
+                    'annotation-function))
+           (strings (selectrum--normalize-collection
+                     minibuffer-completion-table
+                     minibuffer-completion-predicate))
+           (cands ()))
+      (dolist (string strings)
+        (push (propertize string
+                          'selectrum-candidate-display-suffix
+                          (selectrum--get-annotation-suffix string annotf))
+              cands))
       (setq selectrum--preprocessed-candidates
             (funcall (or sortf selectrum-preprocess-candidates-function)
-                     (selectrum--normalize-collection
-                      minibuffer-completion-table
-                      minibuffer-completion-predicate))))))
+                     (nreverse cands))))))
 
 (defun selectrum--minibuffer-post-command-hook ()
   "Update minibuffer in response to user input."

--- a/selectrum.el
+++ b/selectrum.el
@@ -1089,7 +1089,9 @@ copy is made.
 For MINIBUFFER-COMPLETION-TABLE and
 MINIBUFFER-COMPLETION-PREDICATE see `minibuffer-completion-table'
 and `minibuffer-completion-predicate'. They are used for internal
-purposes and compatibility to Emacs completion API."
+purposes and compatibility to Emacs completion API. By passing
+theses as keyword arguments they will be dynamically bound as per
+semantics of `cl-defun'."
   (unless may-modify-candidates
     (setq candidates (copy-sequence candidates)))
   (selectrum--save-global-state

--- a/selectrum.el
+++ b/selectrum.el
@@ -534,6 +534,14 @@ PRED defaults to `minibuffer-completion-predicate'."
        selectrum--end-of-input-marker)
     ""))
 
+(defun selectrum-exhibit ()
+  "Trigger an update of Selectrums completion UI."
+  (when-let ((mini (active-minibuffer-window)))
+    (with-selected-window mini
+      (setq selectrum--preprocessed-candidates nil)
+      (setq selectrum--previous-input-string nil)
+      (selectrum--minibuffer-post-command-hook))))
+
 ;;;; Hook functions
 
 (defun selectrum--count-info ()

--- a/selectrum.el
+++ b/selectrum.el
@@ -1089,7 +1089,7 @@ copy is made.
 For MINIBUFFER-COMPLETION-TABLE and
 MINIBUFFER-COMPLETION-PREDICATE see `minibuffer-completion-table'
 and `minibuffer-completion-predicate'. They are used for internal
-purposes and compatibility to emacs completion API."
+purposes and compatibility to Emacs completion API."
   (unless may-modify-candidates
     (setq candidates (copy-sequence candidates)))
   (selectrum--save-global-state

--- a/selectrum.el
+++ b/selectrum.el
@@ -535,7 +535,7 @@ PRED defaults to `minibuffer-completion-predicate'."
     ""))
 
 (defun selectrum-exhibit ()
-  "Trigger an update of Selectrums completion UI."
+  "Trigger an update of Selectrum's completion UI."
   (when-let ((mini (active-minibuffer-window)))
     (with-selected-window mini
       (when (and minibuffer-completion-table

--- a/selectrum.el
+++ b/selectrum.el
@@ -1042,7 +1042,9 @@ Otherwise, just eval BODY."
     (prompt candidates &rest args &key
             default-candidate initial-input require-match
             history no-move-default-candidate
-            may-modify-candidates)
+            may-modify-candidates
+            minibuffer-completion-table
+            minibuffer-completion-predicate)
   "Prompt user with PROMPT to select one of CANDIDATES.
 Return the selected string.
 
@@ -1082,7 +1084,12 @@ is very confusing.
 
 MAY-MODIFY-CANDIDATES, if non-nil, means that Selectrum is
 allowed to modify the CANDIDATES list destructively. Otherwise a
-copy is made."
+copy is made.
+
+For MINIBUFFER-COMPLETION-TABLE and
+MINIBUFFER-COMPLETION-PREDICATE see `minibuffer-completion-table'
+and `minibuffer-completion-predicate'. They are used for internal
+purposes and compatibility to emacs completion API."
   (unless may-modify-candidates
     (setq candidates (copy-sequence candidates)))
   (selectrum--save-global-state
@@ -1149,7 +1156,9 @@ HIST, DEF, and INHERIT-INPUT-METHOD, see `completing-read'."
    :default-candidate (or (car-safe def) def)
    :require-match (eq require-match t)
    :history hist
-   :may-modify-candidates t))
+   :may-modify-candidates t
+   :minibuffer-completion-table collection
+   :minibuffer-completion-predicate predicate))
 
 (defvar selectrum--old-completing-read-function nil
   "Previous value of `completing-read-function'.")
@@ -1206,7 +1215,9 @@ INHERIT-INPUT-METHOD, see `completing-read-multiple'."
         :initial-input initial-input
         :history hist
         :default-candidate def
-        :may-modify-candidates t)))
+        :may-modify-candidates t
+        :minibuffer-completion-table table
+        :minibuffer-completion-predicate predicate)))
     (split-string res crm-separator t)))
 
 ;;;###autoload
@@ -1255,7 +1266,10 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
       (`0 (message "No match"))
       (`1 (setq result (car cands)))
       ( _ (setq result (selectrum-read
-                        "Completion: " cands :may-modify-candidates t))))
+                        "Completion: " cands
+                        :may-modify-candidates t
+                        :minibuffer-completion-table collection
+                        :minibuffer-completion-predicate predicate))))
     (when result
       (delete-region start end)
       (insert (substring-no-properties result)))
@@ -1310,7 +1324,9 @@ PREDICATE, see `read-buffer'."
      :require-match (eq require-match t)
      :history 'buffer-name-history
      :no-move-default-candidate t
-     :may-modify-candidates t)))
+     :may-modify-candidates t
+     :minibuffer-completion-table #'internal-complete-buffer
+     :minibuffer-completion-predicate predicate)))
 
 (defvar selectrum--old-read-buffer-function nil
   "Previous value of `read-buffer-function'.")
@@ -1355,7 +1371,9 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
      :initial-input (or (car-safe initial-input) initial-input)
      :history hist
      :require-match (eq require-match t)
-     :may-modify-candidates t)))
+     :may-modify-candidates t
+     :minibuffer-completion-table collection
+     :minibuffer-completion-predicate predicate)))
 
 ;;;###autoload
 (defun selectrum-read-file-name

--- a/selectrum.el
+++ b/selectrum.el
@@ -1171,7 +1171,7 @@ For MINIBUFFER-COMPLETION-TABLE and
 MINIBUFFER-COMPLETION-PREDICATE see `minibuffer-completion-table'
 and `minibuffer-completion-predicate'. They are used for internal
 purposes and compatibility to Emacs completion API. By passing
-theses as keyword arguments they will be dynamically bound as per
+these as keyword arguments they will be dynamically bound as per
 semantics of `cl-defun'."
   (unless may-modify-candidates
     (setq candidates (copy-sequence candidates)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -526,10 +526,13 @@ PRED defaults to `minibuffer-completion-predicate'."
           (t strings))))
 
 (defun selectrum--current-input ()
-  "Get current minibuffer input."
-  (buffer-substring
-   selectrum--start-of-input-marker
-   selectrum--end-of-input-marker))
+  "Get current Selectrum input."
+  (if (and selectrum--start-of-input-marker
+           selectrum--end-of-input-marker)
+      (buffer-substring
+       selectrum--start-of-input-marker
+       selectrum--end-of-input-marker)
+    ""))
 
 ;;;; Hook functions
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -475,6 +475,12 @@ This is used to implement `selectrum-repeat'.")
      selectrum--start-of-input-marker
      selectrum--end-of-input-marker)))
 
+(defun selectrum--current-input ()
+  "Get current minibuffer input."
+  (buffer-substring
+   selectrum--start-of-input-marker
+   selectrum--end-of-input-marker))
+
 ;;;; Hook functions
 
 (defun selectrum--count-info ()

--- a/selectrum.el
+++ b/selectrum.el
@@ -538,7 +538,9 @@ PRED defaults to `minibuffer-completion-predicate'."
   "Trigger an update of Selectrums completion UI."
   (when-let ((mini (active-minibuffer-window)))
     (with-selected-window mini
-      (setq selectrum--preprocessed-candidates nil)
+      (when (and minibuffer-completion-table
+                 (not (functionp selectrum--preprocessed-candidates)))
+        (setq selectrum--preprocessed-candidates nil))
       (setq selectrum--previous-input-string nil)
       (selectrum--minibuffer-post-command-hook))))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -543,7 +543,7 @@ just rendering it to the screen and then checking."
 
 (defun selectrum--init-candidates-from-table ()
   "Initialize candidates from `minibuffer-completion-table'."
- (when (and (not selectrum--preprocessed-candidates)
+  (when (and (not selectrum--preprocessed-candidates)
              minibuffer-completion-table)
     (let ((sortf (completion-metadata-get
                   (completion-metadata

--- a/selectrum.el
+++ b/selectrum.el
@@ -510,7 +510,9 @@ INPUT defaults to current selectrum input string."
   "Get candidates from TABLE.
 TABLE defaults to `minibuffer-completion-table'.
 PRED defaults to `minibuffer-completion-predicate'."
-  (let ((annotf (selectrum--get-meta 'annotation-function table pred))
+  (let ((annotf (or (selectrum--get-meta 'annotation-function table pred)
+                    (plist-get completion-extra-properties
+                               :annotation-function)))
         (strings (selectrum--normalize-collection
                   (or table minibuffer-completion-table)
                   (or pred minibuffer-completion-predicate))))


### PR DESCRIPTION
This will allow us to access the metadata for purposes as discussed in  #15 and #82 and allows other packages and commands to access those variables (see #94). With this patch we can retrieve the metadata like:

    (completion-metadata input
                         minibuffer-completion-table
                         minibuffer-completion-predicate)

We could also decide to only pass the metadata instead (which would probably reduce garbage collection when exiting the minibuffer I guess). But the metadata can depend on the current input and the predicate passed to the completion table. Having metadata dependent on the input or predicate sounds like a crazy idea and I don't know if it actually happens in practice.