### PR TITLE
Ignore empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,8 @@ The format is based on [Keep a Changelog].
   fixed. Also, `TAB` now inserts the current candidate and not the
   whole path to the library, so that the result can be submitted
   directly ([#73]).
+* Empty string completion candidates are now ignored like in the
+  default completion UI ([#101]).
 
 [#4]: https://github.com/raxod502/selectrum/issues/4
 [#12]: https://github.com/raxod502/selectrum/issues/12
@@ -178,6 +180,7 @@ The format is based on [Keep a Changelog].
 [#85]: https://github.com/raxod502/selectrum/pull/85
 [#86]: https://github.com/raxod502/selectrum/pull/86
 [#89]: https://github.com/raxod502/selectrum/pull/89
+[#101]: https://github.com/raxod502/selectrum/pull/101
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/selectrum.el
+++ b/selectrum.el
@@ -578,6 +578,8 @@ just rendering it to the screen and then checking."
         (setq selectrum--refined-candidates
               (selectrum--move-to-front-destructive
                input selectrum--refined-candidates))
+        (setq selectrum--refined-candidates
+              (delete "" selectrum--refined-candidates))
         (if selectrum--repeat
             (progn
               (setq selectrum--current-candidate-index


### PR DESCRIPTION
I noticed this with comint input rings where empty strings are contained. In default completion UI empty strings are omitted, as well.
