### PR TITLE
Toggle sorting for special commands

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -783,6 +783,10 @@ into the user input area to start with."
       (insert initial-input)))
   (setq selectrum--end-of-input-marker (point-marker))
   (set-marker-insertion-type selectrum--end-of-input-marker t)
+  ;; Adjust selectrum sorting if configured for command.
+  (when-let ((prop (memq 'selectrum-should-sort-p
+                         (symbol-plist selectrum--last-command))))
+    (setq-local selectrum-should-sort-p (cadr prop)))
   (setq selectrum--preprocessed-candidates
         (if (functionp candidates)
             candidates


### PR DESCRIPTION
I have encountered many cases where I would want to disable sort for some command. Currently one needs to write an advice for the offending command (if it's an external one). An easy mistake is to let bind `selectrum-should-sort-p` which has the issue that the sort option is then bound for all recursive sessions, as well. One would ideally need to use `minibuffer-with-setup-hook` and set `selectrum-should-sort-p` buffer locally to avoid that.

Using this PR package authors and users can easily configure selectrums sort behaviour for special commands like this:

```elisp
(put 'completing-history-insert-item
     'selectrum-should-sort-p nil)
```

If a command does not have this special property the value bound to `selectrum-should-sort-p` would be used as before. 

