### PR TITLE
Add "ext:" to declare-function invocations

### DIFF
--- a/selectrum-helm.el
+++ b/selectrum-helm.el
@@ -29,8 +29,8 @@
 
 (require 'selectrum)
 
-(declare-function helm "helm")
-(declare-function helm-get-current-source "helm")
+(declare-function helm "ext:helm")
+(declare-function helm-get-current-source "ext:helm")
 
 (cl-defun selectrum-helm--normalize-source (source &optional only-one)
   "Normalize single Helm SOURCE alist.


### PR DESCRIPTION
Per the documentation for declare-function, files corresponding to
external packages should have "ext:" as prefix.