### PR TITLE
Add the ability to interact with candidates via the mouse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ The format is based on [Keep a Changelog].
   `completion-extra-properties` are handled, too ([#82], [#95]).
 * One can trigger an update of Selectrum's completions UI manually by
   calling `selectrum-exhibit` ([#95]).
+* You can now interact with candidates via the mouse. Left click
+  (`mouse-1`) selects the candidate, and right click (`mouse-3`)
+  inserts the candidate, just like `RET` and `TAB`, respectively.
 
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,8 @@ The format is based on [Keep a Changelog].
   calling `selectrum-exhibit` ([#95]).
 * You can now interact with candidates via the mouse. Left click
   (`mouse-1`) selects the candidate, and right click (`mouse-3`)
-  inserts the candidate, just like `RET` and `TAB`, respectively.
-
+  inserts the candidate, just like `RET` and `TAB`, respectively. See
+  [#113] and [#118].
 
 ### Enhancements
 * `icomplete-mode` is now automatically disabled when entering
@@ -208,6 +208,8 @@ The format is based on [Keep a Changelog].
 [#96]: https://github.com/raxod502/selectrum/pull/96
 [#99]: https://github.com/raxod502/selectrum/issues/99
 [#101]: https://github.com/raxod502/selectrum/pull/101
+[#113]: https://github.com/raxod502/selectrum/issues/113
+[#118]: https://github.com/raxod502/selectrum/pull/118
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/selectrum.el
+++ b/selectrum.el
@@ -754,6 +754,25 @@ just rendering it to the screen and then checking."
                     (right-margin (get-text-property
                                    0 'selectrum-candidate-display-right-margin
                                    candidate)))
+                ;; Add the ability to interact with candidates via the mouse.
+                (add-text-properties
+                 0 (length displayed-candidate)
+                 (list
+                  'mouse-face 'highlight
+                  'help-echo
+                  "mouse-1: select candidate\nmouse-3: insert candidate"
+                  'keymap
+                  (let ((keymap (make-sparse-keymap)))
+                    (define-key keymap [mouse-1]
+                      `(lambda ()
+                         (interactive)
+                         (selectrum-select-current-candidate ,(1+ index))))
+                    (define-key keymap [mouse-3]
+                      `(lambda ()
+                         (interactive)
+                         (selectrum-insert-current-candidate ,(1+ index))))
+                    keymap))
+                 displayed-candidate)
                 (when (equal index highlighted-index)
                   (setq displayed-candidate
                         (copy-sequence displayed-candidate))


### PR DESCRIPTION
mouse-1 (left click) selects the candidate (like RET).
mouse-3 (right click) inserts the candidate (like TAB).

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
