### PR TITLE
[#120] Try to improve behavior for when default candidate not in list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,20 @@ The format is based on [Keep a Changelog].
   Appearance can be configured using the faces
   `selectrum-completion-annotation`, `selectrum-completion-docsig`,
   and `completions-common-part` ([#86]).
+* `selectrum-read` accepts two additional keyword arguments
+  `minibuffer-completion-table` and
+  `minibuffer-completion-predicate`. These can be used to pass the
+  `completing-read` collection and predicate so they are available for
+  internal handling of completion API features and for other external
+  commands or packages which make use of them ([#94], [#95]).
+* If the completion table passed to `completing-read` provides
+  `annotation-function` or `display-sort-function` in its metadata,
+  Selectrum will use this information to annotate or sort the
+  candidates accordingly. Annotations defined by
+  `completion-extra-properties` are handled, too ([#82], [#95]).
+* One can trigger an update of Selectrum's completions UI manually by
+  calling `selectrum-exhibit` ([#95]).
+
 
 ### Enhancements
 * `icomplete-mode` is now automatically disabled when entering
@@ -182,9 +196,12 @@ The format is based on [Keep a Changelog].
 [#76]: https://github.com/raxod502/selectrum/pull/76
 [#77]: https://github.com/raxod502/selectrum/pull/77
 [#80]: https://github.com/raxod502/selectrum/issues/80
+[#82]: https://github.com/raxod502/selectrum/issues/82
 [#85]: https://github.com/raxod502/selectrum/pull/85
 [#86]: https://github.com/raxod502/selectrum/pull/86
 [#89]: https://github.com/raxod502/selectrum/pull/89
+[#94]: https://github.com/raxod502/selectrum/issues/94
+[#95]: https://github.com/raxod502/selectrum/pull/95
 [#96]: https://github.com/raxod502/selectrum/pull/96
 [#99]: https://github.com/raxod502/selectrum/issues/99
 [#101]: https://github.com/raxod502/selectrum/pull/101

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,23 @@ The format is based on [Keep a Changelog].
   keyword argument `:may-modify-candidates` to re-enable the old
   behavior for cases where it is safe and the performance gains are
   useful. See [#74].
+* Working with the default candidate has been improved in cases where
+  it is not in the candidate list. Such candidates are currently shown
+  in the prompt message. For example, the command `lgrep` might
+  suggest searching through files matching `*.el` instead of just a
+  specific file. See [#120], [#122].
+  * While there is no user input, the default candidate remains
+    visible in the prompt message. Previously, it would be hidden when
+    the prompt line was not selected. Unchanged is the behavior is to
+    hide the default candidate when text is typed, so that it is only
+    visible when it can be submitted (similar to the effect of
+    `minibuffer-electric-default-mode`).
+  * The default candidate shown in the prompt message is now displayed
+    with the face `selectrum-current-candidate` when it is selected.
+  * Now that Selectrum always shows the default candidate when it can
+    be submitted, it now attempts to remove the default candidate from
+    prompt messages that already contain it. This decreases
+    redundancy.
 
 ### Bugs fixed
 * You can now use the undo system in the minibuffer. Previously,
@@ -167,6 +184,9 @@ The format is based on [Keep a Changelog].
   directly ([#73]).
 * Empty string completion candidates are now ignored like in the
   default completion UI ([#101]).
+* The default candidate is now first selected, even when it is not in
+  the candidate list, conforming with expectations. Previously, the
+  first candidate in the list was selected instead. See [#120].
 
 [#4]: https://github.com/raxod502/selectrum/issues/4
 [#12]: https://github.com/raxod502/selectrum/issues/12
@@ -210,6 +230,8 @@ The format is based on [Keep a Changelog].
 [#101]: https://github.com/raxod502/selectrum/pull/101
 [#113]: https://github.com/raxod502/selectrum/issues/113
 [#118]: https://github.com/raxod502/selectrum/pull/118
+[#120]: https://github.com/raxod502/selectrum/issues/120
+[#122]: https://github.com/raxod502/selectrum/pull/122
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ The format is based on [Keep a Changelog].
   `completion-extra-properties` are handled, too ([#82], [#95]).
 * One can trigger an update of Selectrum's completions UI manually by
   calling `selectrum-exhibit` ([#95]).
+* You can now interact with candidates via the mouse. Left click
+  (`mouse-1`) selects the candidate, and right click (`mouse-3`)
+  inserts the candidate, just like `RET` and `TAB`, respectively.
 
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,8 @@ The format is based on [Keep a Changelog].
   calling `selectrum-exhibit` ([#95]).
 * You can now interact with candidates via the mouse. Left click
   (`mouse-1`) selects the candidate, and right click (`mouse-3`)
-  inserts the candidate, just like `RET` and `TAB`, respectively.
-
+  inserts the candidate, just like `RET` and `TAB`, respectively. See
+  [#113] and [#118].
 
 ### Enhancements
 * `icomplete-mode` is now automatically disabled when entering
@@ -208,6 +208,8 @@ The format is based on [Keep a Changelog].
 [#96]: https://github.com/raxod502/selectrum/pull/96
 [#99]: https://github.com/raxod502/selectrum/issues/99
 [#101]: https://github.com/raxod502/selectrum/pull/101
+[#113]: https://github.com/raxod502/selectrum/issues/113
+[#118]: https://github.com/raxod502/selectrum/pull/118
 [raxod502/ctrlf#41]: https://github.com/raxod502/ctrlf/issues/41
 
 ## 1.0 (released 2020-03-23)

--- a/selectrum.el
+++ b/selectrum.el
@@ -671,7 +671,8 @@ just rendering it to the screen and then checking."
                   nil)
                  ((and selectrum--default-candidate
                        (string-empty-p (selectrum--current-input))
-                       (not (member selectrum--default-candidate selectrum--refined-candidates)))
+                       (not (member selectrum--default-candidate
+                                    selectrum--refined-candidates)))
                   -1)
                  (selectrum--move-default-candidate-p
                   0)
@@ -730,7 +731,8 @@ just rendering it to the screen and then checking."
                          (propertize
                           (format " [default value: %S]"
                                   (or (and selectrum--default-candidate
-                                           (substring-no-properties selectrum--default-candidate))
+                                           (substring-no-properties
+                                            selectrum--default-candidate))
                                       'none))
                           'face 'minibuffer-prompt))
                         (ol (make-overlay

--- a/selectrum.el
+++ b/selectrum.el
@@ -728,7 +728,9 @@ just rendering it to the screen and then checking."
                   (let ((str
                          (propertize
                           (format " [default value: %S]"
-                                  (or selectrum--default-candidate 'none))
+                                  (or (and selectrum--default-candidate
+                                           (substring-no-properties selectrum--default-candidate))
+                                      'none))
                           'face 'minibuffer-prompt))
                         (ol (make-overlay
                              ;; Put cursor after overlay.

--- a/selectrum.el
+++ b/selectrum.el
@@ -775,8 +775,7 @@ just rendering it to the screen and then checking."
                          18 (- (length str) 2)
                          'selectrum-current-candidate
                          'append
-                         str)))
-                    )
+                         str))))
                 (add-text-properties
                  (minibuffer-prompt-end) bound
                  '(face selectrum-current-candidate)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -357,6 +357,25 @@ If PREDICATE is non-nil, then it filters the collection as in
   (or (get-text-property 0 'selectrum-candidate-full candidate)
       candidate))
 
+(defun selectrum--get-annotation-suffix (string annotation-func)
+  "Get `selectrum-candidate-display-suffix' value for annotation.
+Used to display STRING according to ANNOTATION-FUNC from
+metadata."
+  ;; Rule out situations where the annotation
+  ;; is nil.
+  (when-let ((annotation (funcall annotation-func string)))
+    (propertize
+     annotation
+     'face 'selectrum-completion-annotation)))
+
+(defun selectrum--get-margin-docsig (string docsig-func)
+  "Get `selectrum-candidate-display-right-margin' value for docsig.
+Used to display STRING according to DOCSIG-FUNC from metadata."
+  (when-let ((docsig (funcall docsig-func string)))
+    (propertize
+     (format "%s" docsig)
+     'face 'selectrum-completion-docsig)))
+
 ;;;; Minibuffer state
 
 (defvar selectrum--start-of-input-marker nil
@@ -475,6 +494,58 @@ This is used to implement `selectrum-repeat'.")
      selectrum--start-of-input-marker
      selectrum--end-of-input-marker)))
 
+(defun selectrum--get-meta (setting &optional table pred input)
+  "Get metadata SETTING from TABLE.
+TABLE defaults to `minibuffer-completion-table'.
+PRED defaults to `minibuffer-completion-predicate'.
+INPUT defaults to current selectrum input string."
+  (let ((input (or input (selectrum--current-input)))
+        (pred (or pred minibuffer-completion-predicate))
+        (table (or table minibuffer-completion-table)))
+    (when table
+      (completion-metadata-get
+       (completion-metadata input table pred) setting))))
+
+(defun selectrum--get-candidates-from-table (&optional table pred)
+  "Get candidates from TABLE.
+TABLE defaults to `minibuffer-completion-table'.
+PRED defaults to `minibuffer-completion-predicate'."
+  (let ((annotf (or (selectrum--get-meta 'annotation-function table pred)
+                    (plist-get completion-extra-properties
+                               :annotation-function)))
+        (strings (selectrum--normalize-collection
+                  (or table minibuffer-completion-table)
+                  (or pred minibuffer-completion-predicate))))
+    (cond (annotf
+           (let ((cands ()))
+             (dolist (string strings (nreverse cands))
+               (push (propertize
+                      string
+                      'selectrum-candidate-display-suffix
+                      (selectrum--get-annotation-suffix
+                       string annotf))
+                     cands))))
+          (t strings))))
+
+(defun selectrum--current-input ()
+  "Get current Selectrum input."
+  (if (and selectrum--start-of-input-marker
+           selectrum--end-of-input-marker)
+      (buffer-substring
+       selectrum--start-of-input-marker
+       selectrum--end-of-input-marker)
+    ""))
+
+(defun selectrum-exhibit ()
+  "Trigger an update of Selectrum's completion UI."
+  (when-let ((mini (active-minibuffer-window)))
+    (with-selected-window mini
+      (when (and minibuffer-completion-table
+                 (not (functionp selectrum--preprocessed-candidates)))
+        (setq selectrum--preprocessed-candidates nil))
+      (setq selectrum--previous-input-string nil)
+      (selectrum--minibuffer-post-command-hook))))
+
 ;;;; Hook functions
 
 (defun selectrum--count-info ()
@@ -550,6 +621,13 @@ just rendering it to the screen and then checking."
           (bound (marker-position selectrum--end-of-input-marker))
           (keep-mark-active (not deactivate-mark)))
       (unless (equal input selectrum--previous-input-string)
+        (when (and (not selectrum--preprocessed-candidates)
+                   minibuffer-completion-table)
+          ;; No candidates were passed, initialize them from
+          ;; `minibuffer-completion-table'.
+          (setq selectrum--preprocessed-candidates
+                (funcall selectrum-preprocess-candidates-function
+                         (selectrum--get-candidates-from-table))))
         (setq selectrum--previous-input-string input)
         ;; Reset the persistent input, so that it will be nil if
         ;; there's no special attention needed.
@@ -785,6 +863,10 @@ into the user input area to start with."
       (insert initial-input)))
   (setq selectrum--end-of-input-marker (point-marker))
   (set-marker-insertion-type selectrum--end-of-input-marker t)
+  ;; If metadata specifies a custom sort function use it as
+  ;; `selectrum-preprocess-candidates-function' for this session.
+  (when-let ((sortf (selectrum--get-meta 'display-sort-function)))
+    (setq-local selectrum-preprocess-candidates-function sortf))
   (setq selectrum--preprocessed-candidates
         (if (functionp candidates)
             candidates
@@ -1054,14 +1136,17 @@ Otherwise, just eval BODY."
     (prompt candidates &rest args &key
             default-candidate initial-input require-match
             history no-move-default-candidate
-            may-modify-candidates)
+            may-modify-candidates
+            minibuffer-completion-table
+            minibuffer-completion-predicate)
   "Prompt user with PROMPT to select one of CANDIDATES.
 Return the selected string.
 
 CANDIDATES is a list of strings or a function to dynamically
 generate them. If CANDIDATES is a function, then it receives one
 argument, the current user input, and returns the list of
-strings.
+strings. If CANDIDATES are nil the candidates will be computed
+from MINIBUFFER-COMPLETION-TABLE.
 
 Instead of a list of strings, the function may alternatively
 return an alist with the following keys:
@@ -1094,7 +1179,14 @@ is very confusing.
 
 MAY-MODIFY-CANDIDATES, if non-nil, means that Selectrum is
 allowed to modify the CANDIDATES list destructively. Otherwise a
-copy is made."
+copy is made.
+
+For MINIBUFFER-COMPLETION-TABLE and
+MINIBUFFER-COMPLETION-PREDICATE see `minibuffer-completion-table'
+and `minibuffer-completion-predicate'. They are used for internal
+purposes and compatibility to Emacs completion API. By passing
+these as keyword arguments they will be dynamically bound as per
+semantics of `cl-defun'."
   (unless may-modify-candidates
     (setq candidates (copy-sequence candidates)))
   (selectrum--save-global-state
@@ -1156,14 +1248,16 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
 HIST, DEF, and INHERIT-INPUT-METHOD, see `completing-read'."
   (ignore initial-input inherit-input-method)
   (selectrum-read
-   prompt (selectrum--normalize-collection collection predicate)
+   prompt nil
    ;; Don't pass `initial-input'. We use it internally but it's
    ;; deprecated in `completing-read' and doesn't work well with the
    ;; Selectrum paradigm except in specific cases that we control.
    :default-candidate (or (car-safe def) def)
    :require-match (eq require-match t)
    :history hist
-   :may-modify-candidates t))
+   :may-modify-candidates t
+   :minibuffer-completion-table collection
+   :minibuffer-completion-predicate predicate))
 
 (defvar selectrum--old-completing-read-function nil
   "Previous value of `completing-read-function'.")
@@ -1220,7 +1314,9 @@ INHERIT-INPUT-METHOD, see `completing-read-multiple'."
         :initial-input initial-input
         :history hist
         :default-candidate def
-        :may-modify-candidates t)))
+        :may-modify-candidates t
+        :minibuffer-completion-table table
+        :minibuffer-completion-predicate predicate)))
     (split-string res crm-separator t)))
 
 ;;;###autoload
@@ -1264,29 +1360,30 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                            cand
                            'selectrum-candidate-display-suffix
                            (when annotation-func
-                             ;; Rule out situations where the annotation
-                             ;; is nil.
-                             (when-let ((annotation
-                                         (funcall annotation-func cand)))
-                               (propertize
-                                annotation
-                                'face 'selectrum-completion-annotation)))
+                             (selectrum--get-annotation-suffix
+                              cand annotation-func))
                            'selectrum-candidate-display-right-margin
                            (when docsig-func
-                             (when-let ((docsig (funcall docsig-func cand)))
-                               (propertize
-                                (format "%s" docsig)
-                                'face 'selectrum-completion-docsig)))))
+                             (selectrum--get-margin-docsig
+                              cand docsig-func))))
                         cands))
                 (selectrum-should-sort-p selectrum-should-sort-p))
            (when display-sort-func
              (setq cands (funcall display-sort-func cands))
+             ;; FIXME: This will set `selectrum-should-sort-p' for any
+             ;; recursive minibuffer sessions, too.
              (setq selectrum-should-sort-p nil))
            (pcase (length cands)
              ;; We already rule out the situation where `cands' is empty.
              (`1 (setq result (car cands)))
              ( _ (setq result (selectrum-read
                                "Completion: " cands
+                               ;; Don't pass
+                               ;; `minibuffer-completion-table' and
+                               ;; `minibuffer-completion-predicate'
+                               ;; here because currently this function
+                               ;; handles all metadata for region
+                               ;; completion itself.
                                :may-modify-candidates t))))
            (setq exit-status
                  (cond ((not (member result cands)) 'sole)
@@ -1340,7 +1437,9 @@ PREDICATE, see `read-buffer'."
      :require-match (eq require-match t)
      :history 'buffer-name-history
      :no-move-default-candidate t
-     :may-modify-candidates t)))
+     :may-modify-candidates t
+     :minibuffer-completion-table #'internal-complete-buffer
+     :minibuffer-completion-predicate predicate)))
 
 (defvar selectrum--old-read-buffer-function nil
   "Previous value of `read-buffer-function'.")
@@ -1385,7 +1484,9 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
      :initial-input (or (car-safe initial-input) initial-input)
      :history hist
      :require-match (eq require-match t)
-     :may-modify-candidates t)))
+     :may-modify-candidates t
+     :minibuffer-completion-table collection
+     :minibuffer-completion-predicate predicate)))
 
 ;;;###autoload
 (defun selectrum-read-file-name

--- a/selectrum.el
+++ b/selectrum.el
@@ -669,6 +669,9 @@ just rendering it to the screen and then checking."
                 (cond
                  ((null selectrum--refined-candidates)
                   nil)
+                 ((and selectrum--default-candidate
+                       (not (member selectrum--default-candidate selectrum--refined-candidates)))
+                  -1)
                  (selectrum--move-default-candidate-p
                   0)
                  (t

--- a/selectrum.el
+++ b/selectrum.el
@@ -717,7 +717,9 @@ just rendering it to the screen and then checking."
           (if (or (and highlighted-index
                        (< highlighted-index 0))
                   (and (not selectrum--match-required-p)
-                       (not displayed-candidates)))
+                       (not displayed-candidates))
+                  (not (member selectrum--default-candidate
+                               selectrum--refined-candidates)))
               (if (= (minibuffer-prompt-end) bound)
                   (let ((str
                          (propertize
@@ -725,8 +727,9 @@ just rendering it to the screen and then checking."
                                   (or selectrum--default-candidate 'none))
                           'face 'minibuffer-prompt))
                         (ol (make-overlay
-                             (minibuffer-prompt-end)
-                             (minibuffer-prompt-end))))
+                             ;; Put cursor after overlay.
+                             (1- (minibuffer-prompt-end))
+                             (1- (minibuffer-prompt-end)))))
                     (put-text-property 0 1 'cursor t str)
                     (overlay-put ol 'after-string str)
                     (setq selectrum--default-value-overlay ol))

--- a/selectrum.el
+++ b/selectrum.el
@@ -741,7 +741,18 @@ just rendering it to the screen and then checking."
                              (1- (minibuffer-prompt-end)))))
                     (put-text-property 0 1 'cursor t str)
                     (overlay-put ol 'after-string str)
-                    (setq selectrum--default-value-overlay ol))
+                    (setq selectrum--default-value-overlay ol)
+                    (when (= -1 selectrum--current-candidate-index)
+                      (if (version< emacs-version "27")
+                          (font-lock-prepend-text-property
+                           18 (- (length str) 2)
+                           'face 'selectrum-current-candidate
+                           str)
+                        (add-face-text-property
+                         18 (- (length str) 2)
+                         'selectrum-current-candidate
+                         'append
+                         str))))
                 (add-text-properties
                  (minibuffer-prompt-end) bound
                  '(face selectrum-current-candidate)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -386,17 +386,18 @@ Used to display STRING according to DOCSIG-FUNC from metadata."
 
 (defun selectrum--remove-default-from-prompt (prompt)
   "Remove the indication of the default value from PROMPT.
-Selectrum has its own methods of indicating the default value, making
-other methods redundant."
-  (let ((regexps selectrum--minibuffer-default-in-prompt-regexps))
-    (cl-dolist (matcher regexps prompt)
-      (let ((regex (if (stringp matcher) matcher (car matcher))))
-        (when (string-match regex prompt)
-          (cl-return
-           (replace-match "" nil nil prompt
-                          (if (consp matcher)
-                              (cadr matcher)
-                            0))))))))
+Selectrum has its own methods for indicating the default value,
+making other methods redundant."
+  (save-match-data
+    (let ((regexps selectrum--minibuffer-default-in-prompt-regexps))
+      (cl-dolist (matcher regexps prompt)
+        (let ((regex (if (stringp matcher) matcher (car matcher))))
+          (when (string-match regex prompt)
+            (cl-return
+             (replace-match "" nil nil prompt
+                            (if (consp matcher)
+                                (cadr matcher)
+                              0)))))))))
 
 ;;;; Minibuffer state
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -724,8 +724,9 @@ just rendering it to the screen and then checking."
                   (and (not selectrum--match-required-p)
                        (not displayed-candidates))
                   (and selectrum--default-candidate
-                        (not (member selectrum--default-candidate
-                                     selectrum--refined-candidates))))
+                       (not minibuffer-completing-file-name)
+                       (not (member selectrum--default-candidate
+                                    selectrum--refined-candidates))))
               (if (= (minibuffer-prompt-end) bound)
                   (let ((str
                          (propertize
@@ -752,7 +753,8 @@ just rendering it to the screen and then checking."
                          18 (- (length str) 2)
                          'selectrum-current-candidate
                          'append
-                         str))))
+                         str)))
+                    )
                 (add-text-properties
                  (minibuffer-prompt-end) bound
                  '(face selectrum-current-candidate)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -670,6 +670,7 @@ just rendering it to the screen and then checking."
                  ((null selectrum--refined-candidates)
                   nil)
                  ((and selectrum--default-candidate
+                       (string-empty-p (selectrum--current-input))
                        (not (member selectrum--default-candidate selectrum--refined-candidates)))
                   -1)
                  (selectrum--move-default-candidate-p

--- a/selectrum.el
+++ b/selectrum.el
@@ -718,8 +718,9 @@ just rendering it to the screen and then checking."
                        (< highlighted-index 0))
                   (and (not selectrum--match-required-p)
                        (not displayed-candidates))
-                  (not (member selectrum--default-candidate
-                               selectrum--refined-candidates)))
+                  (and selectrum--default-candidate
+                        (not (member selectrum--default-candidate
+                                     selectrum--refined-candidates))))
               (if (= (minibuffer-prompt-end) bound)
                   (let ((str
                          (propertize

--- a/selectrum.el
+++ b/selectrum.el
@@ -754,6 +754,25 @@ just rendering it to the screen and then checking."
                     (right-margin (get-text-property
                                    0 'selectrum-candidate-display-right-margin
                                    candidate)))
+                ;; Add the ability to interact with candidates via the mouse.
+                (add-text-properties
+                 0 (length displayed-candidate)
+                 (list
+                  'mouse-face 'highlight
+                  'help-echo
+                  "mouse-1: select candidate\nmouse-3: insert candidate"
+                  'keymap
+                  (let ((keymap (make-sparse-keymap)))
+                    (define-key keymap [mouse-1]
+                      `(lambda ()
+                         (interactive)
+                         (selectrum-select-current-candidate ,(1+ index))))
+                    (define-key keymap [mouse-3]
+                      `(lambda ()
+                         (interactive)
+                         (selectrum-insert-current-candidate ,(1+ index))))
+                    keymap))
+                 displayed-candidate)
                 (when (equal index highlighted-index)
                   (setq displayed-candidate
                         (copy-sequence displayed-candidate))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1459,23 +1459,33 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                   (ematch (file-name-nondirectory input))
                   ;; Adjust original collection for Selectrum.
                   (cands
-                   (condition-case _
-                       (funcall collection dir
-                                (lambda (i)
-                                  (when (and (or (not predicate)
-                                                 (funcall predicate i))
-                                             (not (member
-                                                   i '("./" "../"))))
-                                    (prog1 t
-                                      (add-text-properties
-                                       0 (length i)
-                                       `(selectrum-candidate-full
-                                         ,(concat dir i))
-                                       i))))
-                                t)
-                     ;; May happen in case user quits out
-                     ;; of a TRAMP prompt.
-                     (quit))))
+                   (selectrum--map-destructive
+                    (lambda (i)
+                      (when (string-suffix-p "/" i)
+                        (setq i (substring i 0 (1- (length i))))
+                        (put-text-property
+                         0 (length i)
+                         'selectrum-candidate-display-suffix
+                         "/"
+                         i))
+                      i)
+                    (condition-case _
+                        (funcall collection dir
+                                 (lambda (i)
+                                   (when (and (or (not predicate)
+                                                  (funcall predicate i))
+                                              (not (member
+                                                    i '("./" "../"))))
+                                     (prog1 t
+                                       (add-text-properties
+                                        0 (length i)
+                                        `(selectrum-candidate-full
+                                          ,(concat dir i))
+                                        i))))
+                                 t)
+                      ;; May happen in case user quits out
+                      ;; of a TRAMP prompt.
+                      (quit)))))
              `((input . ,ematch)
                (candidates . ,cands))))))
     (selectrum-read


### PR DESCRIPTION
Hello.

This is an attempt to fix #120. The current behavior has two problems:
1. An item in the list is pre-selected, instead of the default candidate.
2. One must go up to the prompt line to reveal the default candidate, meaning that the default is hidden by default.

I tried to address these in the following way:
1. When the default candidate is not in the list and there is no user input, pre-select the prompt line. That way, one can quickly hit `RET` to get the default, as expected.
2. When the default candidate is not in the list and there is no user input, always display the default candidate in the prompt line. That way, it is still clear what the default is when moving off of the prompt line.

One thing I was not able to figure out is how to make the default candidate display with the face `selectrum-current-candidate` when the prompt line is selected. I think it would be nice for making it clearer that the default candidate is selected.  Currently  it is shown by only removing highlighting from the other candidate. Do you know how to achieve that?

This is only one way to address the problem in #120. Maybe another is to just add the default candidate to the front of the list if it doesn't exist? I don't know what is best for what you want to do.

Please let me know what must be changed. 

Thank you.