### PR TITLE
Use overlay for candidates display and change multiline display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,10 @@ The format is based on [Keep a Changelog].
   assumed that the minibuffer only contains user input would be likely
   to fail ([#124]). This also means `minibuffer-contents` now returns
   the current input only as expected ([#116], [#133]).
-* Multiline candidates are now truncated to display only the first
-  line (skipping potentially leading empty lines). This way the
-  display works better (no gradual scrolling effect) but matched parts
-  of a multiline candidate might be hidden ([#133]).
+* Multiline candidates are now merged into a single line. This
+  improves the display (there is no gradual scrolling effect anymore)
+  but the line might be to long to display. In this case you can
+  scroll the hidden parts into view ([#133]).
 
 ### Bugs fixed
 * Incremental history search via `isearch` wasn't working which has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ The format is based on [Keep a Changelog].
   using an overlay for candidates display. Previously code which
   assumed that the minibuffer only contains user input would be likely
   to fail ([#124]). This also means `minibuffer-contents` now returns
-  the current input only as expected ([#116], [#133]).
+  only the current input as expected ([#116], [#133]).
 * Multiline candidates are now merged into a single line. This
   improves the display (there is no gradual scrolling effect anymore)
   but the line might be to long to display. In this case you can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,19 @@ The format is based on [Keep a Changelog].
   navigate and edit the input more efficently. A binding for
   `backward-kill-sexp` was added to go up a directory with `C-M-DEL`
   ([#138]).
+* Compliance to default minibuffer API has been further improved by
+  using an overlay for candidates display. Previously code which
+  assumed that the minibuffer only contains user input would be likely
+  to fail ([#124]). This also means `minibuffer-contents` now returns
+  the current input only as expected ([#116], [#133]).
+* Multiline candidates are now truncated to display only the first
+  line (skipping potentially leading empty lines). This way the
+  display works better (no gradual scrolling effect) but matched parts
+  of a multiline candidate might be hidden ([#133]).
 
 ### Bugs fixed
+* Incremental history search via `isearch` wasn't working which has
+  been fixed ([#124], [#133]).
 * Empty string completion candidates are now ignored like in the
   default completion UI ([#101]).
 * Text properties are now stripped for standard completion functions
@@ -84,14 +95,17 @@ The format is based on [Keep a Changelog].
 [#107]: https://github.com/raxod502/selectrum/issues/107
 [#108]: https://github.com/raxod502/selectrum/pull/108
 [#113]: https://github.com/raxod502/selectrum/issues/113
+[#116]: https://github.com/raxod502/selectrum/issues/116
 [#118]: https://github.com/raxod502/selectrum/pull/118
 [#120]: https://github.com/raxod502/selectrum/issues/120
 [#122]: https://github.com/raxod502/selectrum/pull/122
+[#124]: https://github.com/raxod502/selectrum/issues/124
 [#125]: https://github.com/raxod502/selectrum/pull/125
 [#126]: https://github.com/raxod502/selectrum/issues/126
 [#127]: https://github.com/raxod502/selectrum/pull/127
 [#130]: https://github.com/raxod502/selectrum/issues/130
 [#132]: https://github.com/raxod502/selectrum/pull/132
+[#133]: https://github.com/raxod502/selectrum/pull/133
 [#138]: https://github.com/raxod502/selectrum/pull/138
 [#140]: https://github.com/raxod502/selectrum/pull/140
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,8 @@ The format is based on [Keep a Changelog].
   ([#116], [#133]).
 * Multiline candidates are now merged into a single truncated line so
   there is no gradual scrolling effect anymore when going through the
-  candidate list. The matched line is shown in front of the merged
-  lines ([#133]).
+  candidate list. The first matched line is shown in front of the
+  merged lines ([#133]).
 
 ### Bugs fixed
 * Incremental history search via `isearch` wasn't working which has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,11 +68,10 @@ The format is based on [Keep a Changelog].
   to fail ([#124]). This also means inside the minibuffer
   `minibuffer-contents` now returns only the current input as expected
   ([#116], [#133]).
-* Multiline candidates are now merged into a single line so there is
-  no gradual scrolling effect anymore when going through the candidate
-  list. The matched line is shown in front of the merged lines. Merged
-  lines can be to long for display but you can scroll hidden parts
-  into view (using `scroll-right`/`scroll-left`) ([#133]).
+* Multiline candidates are now merged into a single truncated line so
+  there is no gradual scrolling effect anymore when going through the
+  candidate list. The matched line is shown in front of the merged
+  lines ([#133]).
 
 ### Bugs fixed
 * Incremental history search via `isearch` wasn't working which has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ The format is based on [Keep a Changelog].
     be submitted, it now attempts to remove the default candidate from
     prompt messages that already contain it. This decreases
     redundancy.
+* When there is no default value the prompt shows `[default-value :
+  ""]` to indicate that you would submit the empty string. Previously
+  it showed `[default-value: none]` ([#133]).
 * When reading file names spaces are now considered symbol
   constituents which means you can use s-expression commands to
   navigate and edit the input more efficently. A binding for
@@ -62,12 +65,14 @@ The format is based on [Keep a Changelog].
 * Compliance to default minibuffer API has been further improved by
   using an overlay for candidates display. Previously code which
   assumed that the minibuffer only contains user input would be likely
-  to fail ([#124]). This also means `minibuffer-contents` now returns
-  only the current input as expected ([#116], [#133]).
-* Multiline candidates are now merged into a single line. This
-  improves the display (there is no gradual scrolling effect anymore)
-  but the line might be to long to display. In this case you can
-  scroll the hidden parts into view ([#133]).
+  to fail ([#124]). This also means inside the minibuffer
+  `minibuffer-contents` now returns only the current input as expected
+  ([#116], [#133]).
+* Multiline candidates are now merged into a single line so there is
+  no gradual scrolling effect anymore when going through the candidate
+  list. The matched line is shown in front of the merged lines. Merged
+  lines can be to long for display but you can scroll hidden parts
+  into view (using `scroll-right`/`scroll-left`) ([#133]).
 
 ### Bugs fixed
 * Incremental history search via `isearch` wasn't working which has

--- a/selectrum.el
+++ b/selectrum.el
@@ -522,7 +522,7 @@ This is non-nil during the first call of
 TABLE defaults to `minibuffer-completion-table'.
 PRED defaults to `minibuffer-completion-predicate'.
 INPUT defaults to current selectrum input string."
-  (let ((input (or input (selectrum--current-input)))
+  (let ((input (or input (minibuffer-contents)))
         (pred (or pred minibuffer-completion-predicate))
         (table (or table minibuffer-completion-table)))
     (when table
@@ -549,15 +549,6 @@ PRED defaults to `minibuffer-completion-predicate'."
                        string annotf))
                      cands))))
           (t strings))))
-
-(defun selectrum--current-input ()
-  "Get current Selectrum input."
-  (if (and selectrum--start-of-input-marker
-           selectrum--end-of-input-marker)
-      (buffer-substring
-       selectrum--start-of-input-marker
-       selectrum--end-of-input-marker)
-    ""))
 
 (defun selectrum-exhibit ()
   "Trigger an update of Selectrum's completion UI."
@@ -646,7 +637,7 @@ PRED defaults to `minibuffer-completion-predicate'."
                ((null selectrum--refined-candidates)
                 nil)
                ((and selectrum--default-candidate
-                     (string-empty-p (selectrum--current-input))
+                     (string-empty-p (minibuffer-contents))
                      (not (member selectrum--default-candidate
                                   selectrum--refined-candidates)))
                 -1)
@@ -654,7 +645,7 @@ PRED defaults to `minibuffer-completion-predicate'."
                      minibuffer-completing-file-name
                      (eq minibuffer-completion-predicate
                          'file-directory-p)
-                     (equal (selectrum--current-input)
+                     (equal (minibuffer-contents)
                             selectrum--default-candidate))
                 ;; When reading directories and the default is the
                 ;; prompt, select it initially.
@@ -956,10 +947,10 @@ into the user input area to start with."
           (max (if (and selectrum--match-required-p
                         (cond (minibuffer-completing-file-name
                                (not (file-exists-p
-                                     (selectrum--current-input))))
+                                     (minibuffer-contents))))
                               (t
                                (not (string-empty-p
-                                     (selectrum--current-input))))))
+                                     (minibuffer-contents))))))
                    0
                  -1)
                (1- selectrum--current-candidate-index)))))
@@ -1057,9 +1048,9 @@ Zero means to select the current user input."
     (when (or (not selectrum--match-required-p)
               (and index (>= index 0))
               (and minibuffer-completing-file-name
-                   (file-exists-p (selectrum--current-input)))
+                   (file-exists-p (minibuffer-contents)))
               (string-empty-p
-               (selectrum--current-input)))
+               (minibuffer-contents)))
       (selectrum--exit-with
        (selectrum--get-candidate index)))))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -773,7 +773,9 @@ Multiline canidates are merged into a single line."
                 "\n" (propertize "\\\\n" 'face 'warning)
                 (replace-regexp-in-string
                  "[ \t][ \t]+" (propertize ".." 'face 'shadow)
-                 (substring cand 0 (min 1000 (length cand))))))))
+                 (concat
+                  (substring cand 0 (min 1000 (length cand)))
+                  (propertize "..." 'face 'warning)))))))
        onelines))))
 
 (defun selectrum--candidates-display-string (candidates

--- a/selectrum.el
+++ b/selectrum.el
@@ -698,7 +698,7 @@ PRED defaults to `minibuffer-completion-predicate'."
                       selectrum-num-candidates-displayed))
       (when (not selectrum-fix-minibuffer-height)
         (let ((needed (1+ (length displayed-candidates))))
-          (when (> (window-height) needed)
+          (when (/= (window-height) needed)
             (setf (window-height) needed))))
       (let ((text (selectrum--candidates-display-string
                    displayed-candidates
@@ -902,8 +902,9 @@ into the user input area to start with."
   (setq-local selectrum--init-p t)
   (setq selectrum--candidates-overlay
         (make-overlay (point) (point) nil 'front-advance 'rear-advance))
-  (enlarge-window (- selectrum-num-candidates-displayed
-                     (1- (window-height))))
+  (when selectrum-fix-minibuffer-height
+    (enlarge-window (- selectrum-num-candidates-displayed
+                       (1- (window-height)))))
   (setq selectrum--start-of-input-marker (point-marker))
   (if selectrum--repeat
       (insert selectrum--previous-input-string)

--- a/selectrum.el
+++ b/selectrum.el
@@ -254,7 +254,9 @@ into the prompt when using commands which use
 
 (defcustom selectrum-fix-minibuffer-height nil
   "Non-nil means the minibuffer always has the same height.
-Even if there are fewer candidates."
+Even if there are fewer candidates. If this option is nil the
+minibuffer height is determined by the initial number of
+candidates."
   :type 'boolean)
 
 (defcustom selectrum-right-margin-padding 1

--- a/selectrum.el
+++ b/selectrum.el
@@ -674,10 +674,11 @@ PRED defaults to `minibuffer-completion-predicate'."
                     (and (not selectrum--match-required-p)
                          (not displayed-candidates)))
                 (if (= (minibuffer-prompt-end) bound)
-                    (setq default (propertize
-                                   (format " [default value: %S]"
-                                           (or selectrum--default-candidate 'none))
-                                   'face 'minibuffer-prompt))
+                    (setq default
+                          (propertize
+                           (format " [default value: %S]"
+                                   (or selectrum--default-candidate 'none))
+                           'face 'minibuffer-prompt))
                   (add-text-properties
                    (minibuffer-prompt-end) bound
                    '(face selectrum-current-candidate)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -824,7 +824,7 @@ into the user input area to start with."
    'minibuffer-exit-hook #'selectrum--minibuffer-exit-hook nil 'local)
   (setq-local selectrum--init-p t)
   (setq selectrum--candidates-overlay
-        (make-overlay (point) (point) nil t t))
+        (make-overlay (point) (point) nil 'front-advance 'rear-advance))
   (enlarge-window (- selectrum-num-candidates-displayed
                      (1- (window-height))))
   (setq selectrum--start-of-input-marker (point-marker))

--- a/selectrum.el
+++ b/selectrum.el
@@ -750,32 +750,16 @@ PRED defaults to `minibuffer-completion-predicate'."
 
 (defun selectrum--first-lines (candidates)
   "Return list of single line CANDIDATES.
-For multi-line canidates only the the first line is taken into
-account (leading empty lines are skipped, truncation is
-indicated)."
+Multiline canidates are merged into a single line."
   (let ((onelines ()))
     (dolist (cand candidates (nreverse onelines))
       (push
        (cond ((not (string-match "\n" cand))
               cand)
-             ((string= "\n" cand)
-              (propertize
-               "\\n" 'face 'warning))
              (t
-              (with-temp-buffer
-                (insert cand)
-                (goto-char (point-min))
-                (concat
-                 (when (and (> (skip-chars-forward " \t\n\r\f\v") 1)
-                            (not
-                             (eq (line-beginning-position)
-                                 (point-min))))
-                   (propertize "...\\n" 'face 'warning))
-                 (buffer-substring (line-beginning-position)
-                                   (line-end-position))
-                 (unless (= (line-end-position) (point-max))
-                   (propertize
-                    "\\n..." 'face 'warning))))))
+              (replace-regexp-in-string
+               "\n" (propertize
+                     "\\\\n" 'face 'warning) cand)))
        onelines))))
 
 (defun selectrum--candidates-display-string (candidates

--- a/selectrum.el
+++ b/selectrum.el
@@ -768,11 +768,12 @@ Multiline canidates are merged into a single line."
                              (minibuffer-contents)
                              (split-string cand "\n"))))
                   (propertize " -> " 'face 'success)))
+               ;; Truncate the rest.
                (replace-regexp-in-string
                 "\n" (propertize "\\\\n" 'face 'warning)
                 (replace-regexp-in-string
                  "[ \t][ \t]+" (propertize ".." 'face 'shadow)
-                 cand)))))
+                 (substring cand 0 (min 1000 (length cand))))))))
        onelines))))
 
 (defun selectrum--candidates-display-string (candidates

--- a/selectrum.el
+++ b/selectrum.el
@@ -252,11 +252,6 @@ This option is a workaround for 2 problems:
   wrapping."
   :type 'integer)
 
-(defcustom selectrum-fix-minibuffer-height nil
-  "Non-nil means the minibuffer always has the same height.
-Even if there are fewer candidates."
-  :type 'boolean)
-
 ;;;; Utility functions
 
 ;;;###autoload
@@ -553,6 +548,8 @@ PRED defaults to `minibuffer-completion-predicate'."
   "Update minibuffer in response to user input."
   (goto-char (max (point) selectrum--start-of-input-marker))
   (goto-char (min (point) selectrum--end-of-input-marker))
+  ;; For some reason this resets and thus can't be set in setup hook.
+  (setq-local truncate-lines t)
   (save-excursion
     (let ((inhibit-read-only t)
           ;; Don't record undo information while messing with the
@@ -808,11 +805,6 @@ candidate."
                 right-margin))
               (push ol selectrum--right-margin-overlays))))
         (cl-incf index))
-      ;; Simplest way to grow the minibuffer to size is to just
-      ;; insert some extra newlines :P
-      (when selectrum-fix-minibuffer-height
-        (dotimes (_ (- selectrum-num-candidates-displayed index))
-          (insert "\n")))
       (buffer-string))))
 
 (defun selectrum--minibuffer-exit-hook ()
@@ -838,6 +830,8 @@ into the user input area to start with."
   (setq-local selectrum--init-p t)
   (setq selectrum--candidates-overlay
         (make-overlay (point) (point) nil t t))
+  (enlarge-window (- selectrum-num-candidates-displayed
+                     (1- (window-height))))
   (setq selectrum--start-of-input-marker (point-marker))
   (if selectrum--repeat
       (insert selectrum--previous-input-string)

--- a/selectrum.el
+++ b/selectrum.el
@@ -759,7 +759,10 @@ Multiline canidates are merged into a single line."
              (t
               (replace-regexp-in-string
                "\n" (propertize
-                     "\\\\n" 'face 'warning) cand)))
+                     "\\\\n" 'face 'warning)
+               (replace-regexp-in-string
+                "[ \t][ \t]+"
+                (propertize ".." 'face 'shadow) cand))))
        onelines))))
 
 (defun selectrum--candidates-display-string (candidates

--- a/selectrum.el
+++ b/selectrum.el
@@ -698,7 +698,7 @@ PRED defaults to `minibuffer-completion-predicate'."
                       selectrum-num-candidates-displayed))
       (when (not selectrum-fix-minibuffer-height)
         (let ((needed (1+ (length displayed-candidates))))
-          (when (/= (window-height) needed)
+          (when (> (window-height) needed)
             (setf (window-height) needed))))
       (let ((text (selectrum--candidates-display-string
                    displayed-candidates

--- a/selectrum.el
+++ b/selectrum.el
@@ -252,7 +252,7 @@ into the prompt when using commands which use
 `completing-read-multiple'."
   :type 'boolean)
 
-(defcustom selectrum-fix-minibuffer-height t
+(defcustom selectrum-fix-minibuffer-height nil
   "Non-nil means the minibuffer always has the same height.
 Even if there are fewer candidates."
   :type 'boolean)
@@ -696,7 +696,8 @@ PRED defaults to `minibuffer-completion-predicate'."
       (setq displayed-candidates
             (seq-take displayed-candidates
                       selectrum-num-candidates-displayed))
-      (when (not selectrum-fix-minibuffer-height)
+      (when (and selectrum--init-p
+                 (not selectrum-fix-minibuffer-height))
         (let ((needed (1+ (length displayed-candidates))))
           (when (/= (window-height) needed)
             (setf (window-height) needed))))

--- a/selectrum.el
+++ b/selectrum.el
@@ -252,7 +252,7 @@ into the prompt when using commands which use
 `completing-read-multiple'."
   :type 'boolean)
 
-(defcustom selectrum-fix-minibuffer-height nil
+(defcustom selectrum-fix-minibuffer-height t
   "Non-nil means the minibuffer always has the same height.
 Even if there are fewer candidates."
   :type 'boolean)

--- a/selectrum.el
+++ b/selectrum.el
@@ -698,11 +698,11 @@ PRED defaults to `minibuffer-completion-predicate'."
       (setq displayed-candidates
             (seq-take displayed-candidates
                       selectrum-num-candidates-displayed))
-      (when (and selectrum--init-p
-                 (not selectrum-fix-minibuffer-height))
-        (let ((needed (1+ (length displayed-candidates))))
-          (when (/= (window-height) needed)
-            (setf (window-height) needed))))
+      (when selectrum--init-p
+        (let ((n (1+ (if selectrum-fix-minibuffer-height
+                         selectrum-num-candidates-displayed
+                       (length displayed-candidates)))))
+          (setf (window-height) n)))
       (let ((text (selectrum--candidates-display-string
                    displayed-candidates
                    input
@@ -905,9 +905,6 @@ into the user input area to start with."
   (setq-local selectrum--init-p t)
   (setq selectrum--candidates-overlay
         (make-overlay (point) (point) nil 'front-advance 'rear-advance))
-  (when selectrum-fix-minibuffer-height
-    (enlarge-window (- selectrum-num-candidates-displayed
-                       (1- (window-height)))))
   (setq selectrum--start-of-input-marker (point-marker))
   (if selectrum--repeat
       (insert selectrum--previous-input-string)

--- a/selectrum.el
+++ b/selectrum.el
@@ -762,13 +762,11 @@ For multi-line canidates only the the first line is taken into
 account (the truncation is indicated)."
   (let ((onelines ()))
     (dolist (cand candidates (nreverse onelines))
-      (if-let ((nl (string-match "\n" cand)))
-          (push (concat (substring cand 0 nl)
+      (if-let ((nl (string-match "\n" cand))
+               (line (substring cand 0 nl)))
+          (push (concat line
                         (propertize
-                         (concat (or (and (char-displayable-p ?⬎)
-                                          "⬎")
-                                     "\\n")
-                                 "...") 'face 'shadow))
+                         "\\n..." 'face 'warning))
                 onelines)
         (push cand onelines)))))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -747,12 +747,16 @@ PRED defaults to `minibuffer-completion-predicate'."
 (defun selectrum--first-lines (candidates)
   "Return list on single line CANDIDATES.
 For multi-line canidates only the the first line is taken into
-account (the truncation is indicated by '...')."
+account (the truncation is indicated)."
   (let ((onelines ()))
     (dolist (cand candidates (nreverse onelines))
       (if-let ((nl (string-match "\n" cand)))
           (push (concat (substring cand 0 nl)
-                        (propertize "..." 'face 'shadow))
+                        (propertize
+                         (concat (or (and (char-displayable-p ?⬎)
+                                          "⬎")
+                                     "\\n")
+                                 "...") 'face 'shadow))
                 onelines)
         (push cand onelines)))))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -252,6 +252,11 @@ into the prompt when using commands which use
 `completing-read-multiple'."
   :type 'boolean)
 
+(defcustom selectrum-fix-minibuffer-height nil
+  "Non-nil means the minibuffer always has the same height.
+Even if there are fewer candidates."
+  :type 'boolean)
+
 (defcustom selectrum-right-margin-padding 1
   "The number of spaces to add after right margin text.
 This only takes effect when the
@@ -691,6 +696,10 @@ PRED defaults to `minibuffer-completion-predicate'."
       (setq displayed-candidates
             (seq-take displayed-candidates
                       selectrum-num-candidates-displayed))
+      (when (not selectrum-fix-minibuffer-height)
+        (let ((needed (1+ (length displayed-candidates))))
+          (when (/= (window-height) needed)
+            (setf (window-height) needed))))
       (let ((text (selectrum--candidates-display-string
                    displayed-candidates
                    input

--- a/selectrum.el
+++ b/selectrum.el
@@ -715,7 +715,7 @@ PRED defaults to `minibuffer-completion-predicate'."
                                (or (and selectrum--default-candidate
                                         (substring-no-properties
                                          selectrum--default-candidate))
-                                   'none)
+                                   "\"\"")
                                'face
                                (if (and selectrum--current-candidate-index
                                         (< selectrum--current-candidate-index

--- a/selectrum.el
+++ b/selectrum.el
@@ -663,35 +663,31 @@ PRED defaults to `minibuffer-completion-predicate'."
           (when selectrum--default-value-overlay
             (delete-overlay selectrum--default-value-overlay)
             (setq selectrum--default-value-overlay nil))
-          (if (or (and highlighted-index
-                       (< highlighted-index 0))
-                  (and (not selectrum--match-required-p)
-                       (not displayed-candidates)))
-              (if (= (minibuffer-prompt-end) bound)
-                  (let ((str
-                         (propertize
-                          (format " [default value: %S]"
-                                  (or selectrum--default-candidate 'none))
-                          'face 'minibuffer-prompt))
-                        (ol (make-overlay
-                             (minibuffer-prompt-end)
-                             (minibuffer-prompt-end))))
-                    (put-text-property 0 1 'cursor t str)
-                    (overlay-put ol 'after-string str)
-                    (setq selectrum--default-value-overlay ol))
-                (add-text-properties
-                 (minibuffer-prompt-end) bound
-                 '(face selectrum-current-candidate)))
-            (remove-text-properties
-             (minibuffer-prompt-end) bound
-             '(face selectrum-current-candidate)))
           (let ((text (selectrum--candidates-display-string
                        displayed-candidates
                        input
                        highlighted-index
-                       first-index-displayed)))
+                       first-index-displayed))
+                (default nil))
+            (if (or (and highlighted-index
+                         (< highlighted-index 0))
+                    (and (not selectrum--match-required-p)
+                         (not displayed-candidates)))
+                (if (= (minibuffer-prompt-end) bound)
+                    (setq default (propertize
+                                   (format " [default value: %S]"
+                                           (or selectrum--default-candidate 'none))
+                                   'face 'minibuffer-prompt))
+                  (add-text-properties
+                   (minibuffer-prompt-end) bound
+                   '(face selectrum-current-candidate)))
+              (remove-text-properties
+               (minibuffer-prompt-end) bound
+               '(face selectrum-current-candidate)))
             (move-overlay selectrum--candidates-overlay
                           (point) (point) (current-buffer))
+            (when default
+              (setq text (concat default text)))
             (put-text-property 0 1 'cursor t text)
             (overlay-put selectrum--candidates-overlay 'after-string text)))
         (setq selectrum--end-of-input-marker (set-marker (make-marker) bound))


### PR DESCRIPTION
As discussed previously (#116, #124) switching to overlays will solve a number of issues because Elisp code usually assumes that the  minibuffer only contains the current user input. 

I had to remove the code which handled display improvements for multi-line candidates. I currently don't know how to reimplement something similar for the overlay approach. Do you know of a way to check the visibility status within the overlay string?

Because of display issues I also had to change the way the mini window height got set which in effect sets the window height constantly so I removed the user option `selectrum-fix-minibuffer-height` for now. I prefer to have a constant height anyway but maybe it would be better to keep it? One could check the number of actual displayed candidates and resize the window accordingly in `selectrum--minibuffer-post-command-hook`.