### PR TITLE
Fix prompt highlight issue

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -796,9 +796,12 @@ just rendering it to the screen and then checking."
                          'selectrum-current-candidate
                          'append
                          str))))
-                (add-text-properties
-                 (minibuffer-prompt-end) bound
-                 '(face selectrum-current-candidate)))
+                (unless (or (and highlighted-index
+                                 (>= highlighted-index 0))
+                            selectrum--match-required-p)
+                  (add-text-properties
+                   (minibuffer-prompt-end) bound
+                   '(face selectrum-current-candidate))))
             (remove-text-properties
              (minibuffer-prompt-end) bound
              '(face selectrum-current-candidate)))


### PR DESCRIPTION
After #122 the prompt gets highlighted for cases where it shouldn't:

To reproduce:

```elisp
(completing-read "Test: "
                 (list "test" "this")
                 nil nil nil nil  "this")
```

Type `te` in the prompt and you see that both the prompt **and** the current candidate are highlighted.

