### PR TITLE
Fix candidate insertion for non default crm-separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ The format is based on [Keep a Changelog].
 * The default candidate is now first selected, even when it is not in
   the candidate list, conforming with expectations. Previously, the
   first candidate in the list was selected instead. See [#120].
+* `selectrum-insert-current-candidate` now works correctly for
+  `completing-read-multiple` when `crm-separator` has a non default
+  value. Previously it would replace the separator with commas when
+  adding new candidates ([#140]).
 
 [#67]: https://github.com/raxod502/selectrum/issues/67
 [#82]: https://github.com/raxod502/selectrum/issues/82
@@ -83,6 +87,7 @@ The format is based on [Keep a Changelog].
 [#127]: https://github.com/raxod502/selectrum/pull/127
 [#130]: https://github.com/raxod502/selectrum/issues/130
 [#132]: https://github.com/raxod502/selectrum/pull/132
+[#140]: https://github.com/raxod502/selectrum/pull/140
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1114,20 +1114,17 @@ list). A null or non-positive ARG inserts the candidate corresponding to
                         (min (1- (prefix-numeric-value arg))
                              (1- (length selectrum--refined-candidates)))
                       selectrum--current-candidate-index)))
-    (delete-region selectrum--start-of-input-marker
-                   selectrum--end-of-input-marker)
+    (if (or (not selectrum--crm-p)
+            (not (re-search-backward crm-separator
+                                     (minibuffer-prompt-end) t)))
+        (delete-region selectrum--start-of-input-marker
+                       selectrum--end-of-input-marker)
+      (goto-char (match-end 0))
+      (delete-region (point) selectrum--end-of-input-marker))
     (let* ((candidate (nth index
                            selectrum--refined-candidates))
            (full (selectrum--get-full candidate)))
-      (insert (if (not selectrum--crm-p)
-                  full
-                (let ((string ""))
-                  (dolist (str (butlast
-                                (split-string
-                                 selectrum--previous-input-string
-                                 crm-separator)))
-                    (setq string (concat string str ",")))
-                  (concat string full))))
+      (insert full)
       (add-to-history minibuffer-history-variable full)
       (apply
        #'run-hook-with-args


### PR DESCRIPTION
The insertion of additional candidates went wrong for non default `crm-seperator`.  