### PR TITLE
Make truncation/replacement indicators customizable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,8 @@ The format is based on [Keep a Changelog].
 * Multiline candidates are now merged into a single truncated line so
   there is no gradual scrolling effect anymore when going through the
   candidate list. The first matched line is shown in front of the
-  merged lines ([#133]).
+  merged lines ([#133]). The strings used to indicate these
+  transformations are customizable ([#147]).
 
 ### Bugs fixed
 * Incremental history search via `isearch` wasn't working which has
@@ -112,6 +113,7 @@ The format is based on [Keep a Changelog].
 [#133]: https://github.com/raxod502/selectrum/pull/133
 [#138]: https://github.com/raxod502/selectrum/pull/138
 [#140]: https://github.com/raxod502/selectrum/pull/140
+[#147]: https://github.com/raxod502/selectrum/pull/147
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,8 @@ The format is based on [Keep a Changelog].
 * Multiline candidates are now merged into a single truncated line so
   there is no gradual scrolling effect anymore when going through the
   candidate list. The first matched line is shown in front of the
-  merged lines ([#133]). The strings used to indicate these
-  transformations are customizable ([#147]).
+  merged lines ([#133]). A user option exists to change the function
+  that performs this transformation ([#147]).
 
 ### Bugs fixed
 * Incremental history search via `isearch` wasn't working which has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,8 @@ The format is based on [Keep a Changelog].
 * Multiline candidates are now merged into a single truncated line so
   there is no gradual scrolling effect anymore when going through the
   candidate list. The first matched line is shown in front of the
-  merged lines ([#133]). A user option exists to change the function
-  that performs this transformation ([#147]).
+  merged lines ([#133]). The indicators used in these transformations
+  are customizable ([#147]).
 
 ### Bugs fixed
 * Dynamic collection functions can now reuse their returned
@@ -120,11 +120,8 @@ The format is based on [Keep a Changelog].
 [#133]: https://github.com/raxod502/selectrum/pull/133
 [#138]: https://github.com/raxod502/selectrum/pull/138
 [#140]: https://github.com/raxod502/selectrum/pull/140
-<<<<<<< HEAD
 [#147]: https://github.com/raxod502/selectrum/pull/147
-=======
 [#152]: https://github.com/raxod502/selectrum/pull/152
->>>>>>> upstream/master
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,8 @@ The format is based on [Keep a Changelog].
 * Multiline candidates are now merged into a single truncated line so
   there is no gradual scrolling effect anymore when going through the
   candidate list. The first matched line is shown in front of the
-  merged lines ([#133]). The indicators used in these transformations
-  are customizable ([#147]).
+  merged lines ([#133]). The indicators used to represent this
+  formatting are customizable ([#147]).
 
 ### Bugs fixed
 * The mininbuffer height is now determined by the actual height of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,8 +74,8 @@ The format is based on [Keep a Changelog].
 * Multiline candidates are now merged into a single truncated line so
   there is no gradual scrolling effect anymore when going through the
   candidate list. The first matched line is shown in front of the
-  merged lines ([#133]). The indicators used to represent this
-  formatting are customizable ([#147]).
+  merged lines ([#133]). This formatting is customizable via
+  `selectrum-multiline-display-settings` ([#147]).
 
 ### Bugs fixed
 * The mininbuffer height is now determined by the actual height of

--- a/selectrum.el
+++ b/selectrum.el
@@ -294,7 +294,7 @@ candidate. This option affects how such formatting looks.
 This formatting does not affect the actual value of a candidate.
 
 When customizing this option, a setting for each transformation
-(defined below) must be present in the list.
+\(defined below) must be present in the list.
 
 There are three values that make a setting:
 1. A symbol from the following list:

--- a/selectrum.el
+++ b/selectrum.el
@@ -939,7 +939,7 @@ candidate."
         (lines
          (selectrum--ensure-single-lines
           ;; First pass the candidates to the highlight function
-          ;; before stipping multi-lines because it might expect
+          ;; before stripping multi-lines because it might expect
           ;; getting passed the same candidates as were passed
           ;; to the filter function (for example `orderless'
           ;; requires this).

--- a/selectrum.el
+++ b/selectrum.el
@@ -276,6 +276,22 @@ This option is a workaround for 2 problems:
   wrapping."
   :type 'integer)
 
+(defcustom selectrum-horizontal-whitespace-indicator ".."
+  "String used to indicate horizontal whitespace when displaying candidates."
+  :type 'string)
+
+(defcustom selectrum-matching-line-indicator " -> "
+  "String used to indicate which line of a candidate matches the query."
+  :type 'string)
+
+(defcustom selectrum-newline-indicator "\\\\n"
+  "String used to indicate line endings when displaying candidates."
+  :type 'string)
+
+(defcustom selectrum-truncated-candidate-indicator "..."
+  "String used to indicate that the candidate has been truncated."
+  :type 'string)
+
 ;;;; Utility functions
 
 ;;;###autoload
@@ -762,22 +778,26 @@ Multiline canidates are merged into a single line."
                  ;; Show first matched line.
                  (concat
                   (replace-regexp-in-string
-                   "[ \t][ \t]+" (propertize ".." 'face 'shadow)
+                   "[ \t][ \t]+" (propertize selectrum-horizontal-whitespace-indicator
+                                             'face 'shadow)
                    (car
                     (funcall selectrum-refine-candidates-function
                              (minibuffer-contents)
                              (split-string cand "\n"))))
-                  (propertize " -> " 'face 'success)))
+                  (propertize selectrum-matching-line-indicator
+                              'face 'success)))
                ;; Truncate the rest.
                (replace-regexp-in-string
-                "\n" (propertize "\\\\n" 'face 'warning)
+                "\n" (propertize selectrum-newline-indicator 'face 'warning)
                 (replace-regexp-in-string
-                 "[ \t][ \t]+" (propertize ".." 'face 'shadow)
+                 "[ \t][ \t]+" (propertize selectrum-horizontal-whitespace-indicator
+                                           'face 'shadow)
                  (if (< (length cand) 1000)
                      cand
                    (concat
                     (substring cand 0 1000)
-                    (propertize "..." 'face 'warning))))))))
+                    (propertize selectrum-truncated-candidate-indicator
+                                'face 'warning))))))))
        onelines))))
 
 (defun selectrum--candidates-display-string (candidates

--- a/selectrum.el
+++ b/selectrum.el
@@ -283,26 +283,36 @@ This option is a workaround for 2 problems:
     (truncation "..." shadow)
     (newline    "\\n" warning)
     (whitespace ".."  shadow))
-  "Indicators used to represent formatting in multi-line candidates.
+  "Settings used to configure the formatting of multi-line candidates.
 
 Currently, multi-line candidates are flattened, stripped of
 repeated whitespace, and, if need be, truncated. Additionally,
 when a multi-line candidate matches the user's input, the
 matching line is also displayed at the beginning of the
-candidate. This formatting does not affect the actual value of a
-candidate.
+candidate. This option affects how such formatting looks.
 
-When customizing this option, all indicators must be present in
-the list. They are `match', `truncation', `newline', and
-`whitespace'.
+This formatting does not affect the actual value of a candidate.
 
-There are two values that make a transformation:
-1. A string to indicate the display change, such as `\"..\"', which
-   replaces repeated whitespace.
-2. A face to assign to the indicator string, such as `shadow'.
+When customizing this option, a setting for each transformation
+(defined below) must be present in the list.
 
-Therefore, a setting is represented, e.g., as
-`(whitespace \"..\" shadow)'."
+There are three values that make a setting:
+1. A symbol from the following list:
+   - `newline' determines the string used to replace line breaks in the
+   candidate, which flattens the candidate into one line.
+   - `whitespace' determines the string used to replace repeated
+   whitespace, which shortens the candidate.
+   - `truncation' determines the string to append to a flattened and
+   truncated candidate.
+   - `match' determines the string to insert between the matching
+    line and the flattened candidate.
+2. A string to indicate the display change.
+3. A face to assign to the indicator string.
+
+Therefore, a setting is represented as a list with three
+elements: a symbol, a string, and a face, in that order.
+This option is itself a list of 4 sub-lists, one for each
+setting."
   :type '(repeat (list :tag "Display settings"
                        (choice (const :tag "Matching line"
                                       match)

--- a/selectrum.el
+++ b/selectrum.el
@@ -301,7 +301,16 @@ There are two values that make a transformation:
 2. A face with which to display the indicator, such as `shadow'.
 
 In this way, a transformation is represented, e.g., as
-`(whitespace :indicator \"..\" :face shadow)'.")
+`(whitespace :indicator \"..\" :face shadow)'."
+  :options '(match truncation newline whitespace)
+  :type  '(alist :key-type (choice (const match)
+                                   (const truncation)
+                                   (const newline)
+                                   (const whitespace))
+                 :value-type (list (const :indicator)
+                                   (string :tag "Indicator string")
+                                   (const :face)
+                                   (face :tag "Indicator face"))))
 
 ;;;; Utility functions
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -914,8 +914,8 @@ Multi-line canidates are merged into a single line."
                                     'face truncation/face))))
              ;; Replacements should be fixed-case and literal, to make things
              ;; simpler.
-             t t)
-            t t)
+             'fixed-case 'literal)
+            'fixed-case 'literal)
          cand)
        single/lines))))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -778,8 +778,9 @@ Multiline canidates are merged into a single line."
                  ;; Show first matched line.
                  (concat
                   (replace-regexp-in-string
-                   "[ \t][ \t]+" (propertize selectrum-horizontal-whitespace-indicator
-                                             'face 'shadow)
+                   "[ \t][ \t]+"
+                   (propertize selectrum-horizontal-whitespace-indicator
+                               'face 'shadow)
                    (car
                     (funcall selectrum-refine-candidates-function
                              (minibuffer-contents)
@@ -790,8 +791,9 @@ Multiline canidates are merged into a single line."
                (replace-regexp-in-string
                 "\n" (propertize selectrum-newline-indicator 'face 'warning)
                 (replace-regexp-in-string
-                 "[ \t][ \t]+" (propertize selectrum-horizontal-whitespace-indicator
-                                           'face 'shadow)
+                 "[ \t][ \t]+"
+                 (propertize selectrum-horizontal-whitespace-indicator
+                             'face 'shadow)
                  (if (< (length cand) 1000)
                      cand
                    (concat

--- a/selectrum.el
+++ b/selectrum.el
@@ -293,8 +293,8 @@ candidate. This formatting does not affect the actual value of a
 candidate.
 
 When customizing this option, all indicators must be present in
-the list. They are \"match\", \"truncation\", \"newline\", and
-\"whitespace\".
+the list. They are `match', `truncation', `newline', and
+`whitespace'.
 
 There are two values that make a transformation:
 1. A string to indicate the display change, such as `\"..\"', which

--- a/selectrum.el
+++ b/selectrum.el
@@ -773,9 +773,11 @@ Multiline canidates are merged into a single line."
                 "\n" (propertize "\\\\n" 'face 'warning)
                 (replace-regexp-in-string
                  "[ \t][ \t]+" (propertize ".." 'face 'shadow)
-                 (concat
-                  (substring cand 0 (min 1000 (length cand)))
-                  (propertize "..." 'face 'warning)))))))
+                 (if (< (length cand) 1000)
+                     cand
+                   (concat
+                    (substring cand 0 1000)
+                    (propertize "..." 'face 'warning))))))))
        onelines))))
 
 (defun selectrum--candidates-display-string (candidates

--- a/selectrum.el
+++ b/selectrum.el
@@ -863,7 +863,7 @@ currently displayed candidates."
 (defun selectrum--ensure-single-lines (candidates)
   "Return list of single line CANDIDATES.
 Multi-line canidates are merged into a single line."
-  (let* ((single-line-candidates ())
+  (let* ((single/lines ())
 
          ;; The indicators are the same for all multi-line candidates, and so
          ;; only need to be gotten from `selectrum-multiline-display-settings'
@@ -889,7 +889,7 @@ Multi-line canidates are merged into a single line."
          (whitespace/display (car whitespace/transformation))
          (whitespace/face (cadr whitespace/transformation)))
 
-    (dolist (cand candidates (nreverse single-line-candidates))
+    (dolist (cand candidates (nreverse single/lines))
       (push
        (if (string-match-p "\n" cand)
            (replace-regexp-in-string
@@ -917,7 +917,7 @@ Multi-line canidates are merged into a single line."
              t t)
             t t)
          cand)
-       single-line-candidates))))
+       single/lines))))
 
 (defun selectrum--candidates-display-string (candidates
                                              input

--- a/selectrum.el
+++ b/selectrum.el
@@ -868,41 +868,35 @@ Multi-line canidates are merged into a single line."
          ;; The indicators are the same for all multi-line candidates, and so
          ;; only need to be gotten from `selectrum-multiline-display-settings'
          ;; once.
-         (selectrum--match-transformation
+         ;; - Matching lines
+         (match/transformation
           (alist-get 'match selectrum-multiline-display-settings))
-         (selectrum--match-display
-          (car selectrum--match-transformation))
-         (selectrum--match-face
-          (cadr selectrum--match-transformation))
-         (selectrum--truncation-transformation
+         (match/display (car match/transformation))
+         (match/face (cadr match/transformation))
+         ;; - Truncated candidate
+         (truncation/transformation
           (alist-get 'truncation selectrum-multiline-display-settings))
-         (selectrum--truncation-display
-          (car selectrum--truncation-transformation))
-         (selectrum--truncation-face
-          (cadr selectrum--truncation-transformation))
-         (selectrum--newline-transformation
+         (truncation/display (car truncation/transformation))
+         (truncation/face (cadr truncation/transformation))
+         ;; - Newlines
+         (newline/transformation
           (alist-get 'newline selectrum-multiline-display-settings))
-         (selectrum--newline-display
-          (car selectrum--newline-transformation))
-         (selectrum--newline-face
-          (cadr selectrum--newline-transformation))
-         (selectrum--whitespace-transformation
+         (newline/display (car newline/transformation))
+         (newline/face (cadr newline/transformation))
+         ;; - Repeated whitespace
+         (whitespace/transformation
           (alist-get 'whitespace selectrum-multiline-display-settings))
-         (selectrum--whitespace-display
-          (car selectrum--whitespace-transformation))
-         (selectrum--whitespace-face
-          (cadr selectrum--whitespace-transformation)))
+         (whitespace/display (car whitespace/transformation))
+         (whitespace/face (cadr whitespace/transformation)))
 
     (dolist (cand candidates (nreverse single-line-candidates))
       (push
        (if (string-match-p "\n" cand)
            (replace-regexp-in-string
-            "\n" (propertize selectrum--newline-display
-                             'face selectrum--newline-face)
+            "\n" (propertize newline/display 'face newline/face)
             (replace-regexp-in-string
              "[ \t][ \t]+"
-             (propertize selectrum--whitespace-display
-                         'face selectrum--whitespace-face)
+             (propertize whitespace/display 'face whitespace/face)
              (concat (unless (string-empty-p (minibuffer-contents))
                        ;; Show first matched line.
                        (when-let ((match
@@ -911,14 +905,13 @@ Multi-line canidates are merged into a single line."
                                          (minibuffer-contents)
                                          (split-string cand "\n")))))
                          (concat match
-                                 (propertize selectrum--match-display
-                                             'face selectrum--match-face))))
+                                 (propertize match/display 'face match/face))))
                      (if (< (length cand) 1000)
                          cand
                        (concat
                         (substring cand 0 1000)
-                        (propertize selectrum--truncation-display
-                                    'face selectrum--truncation-face))))
+                        (propertize truncation/display
+                                    'face truncation/face))))
              ;; Replacements should be fixed-case and literal, to make things
              ;; simpler.
              t t)

--- a/selectrum.el
+++ b/selectrum.el
@@ -302,7 +302,6 @@ There are two values that make a transformation:
 
 In this way, a transformation is represented, e.g., as
 `(whitespace :indicator \"..\" :face shadow)'."
-  :options '(match truncation newline whitespace)
   :type  '(alist :key-type (choice (const match)
                                    (const truncation)
                                    (const newline)

--- a/selectrum.el
+++ b/selectrum.el
@@ -841,16 +841,20 @@ Multi-line canidates are merged into a single line."
          ;; The indicators are the same for all multi-line candidates, and so
          ;; only need to be gotten from `selectrum-candidate-transformations'
          ;; once.
-         (match-transformation (alist-get 'match selectrum-candidate-transformations))
+         (match-transformation
+          (alist-get 'match selectrum-candidate-transformations))
          (match-display (plist-get match-transformation :indicator))
          (match-face (plist-get match-transformation :face))
-         (truncation-transformation (alist-get 'truncation selectrum-candidate-transformations))
+         (truncation-transformation
+          (alist-get 'truncation selectrum-candidate-transformations))
          (truncation-display (plist-get truncation-transformation :indicator))
          (truncation-face (plist-get truncation-transformation :face))
-         (newline-transformation (alist-get 'newline selectrum-candidate-transformations))
+         (newline-transformation
+          (alist-get 'newline selectrum-candidate-transformations))
          (newline-display (plist-get newline-transformation :indicator))
          (newline-face (plist-get newline-transformation :face))
-         (whitespace-transformation (alist-get 'whitespace selectrum-candidate-transformations))
+         (whitespace-transformation
+          (alist-get 'whitespace selectrum-candidate-transformations))
          (whitespace-display (plist-get whitespace-transformation :indicator))
          (whitespace-face (plist-get whitespace-transformation :face)))
 
@@ -875,7 +879,8 @@ Multi-line canidates are merged into a single line."
                          cand
                        (concat
                         (substring cand 0 1000)
-                        (propertize truncation-display 'face truncation-face))))
+                        (propertize truncation-display
+                                    'face truncation-face))))
              ;; Replacements should be fixed-case and literal, to make things
              ;; simpler.
              t t)

--- a/selectrum.el
+++ b/selectrum.el
@@ -283,23 +283,25 @@ This option is a workaround for 2 problems:
     (truncation "..." shadow)
     (newline    "\\n" warning)
     (whitespace ".."  shadow))
-  "Indicators used to represent transformations in displayed candidates.
-This formatting does not affect the actual value of a candidate.
-By default, in the case of multi-line candidates, said candidates
-are flattened, long candidates are truncated, repeated whitespace
-is shortened, and the matching line in a multi-line candidate is
-displayed at the front.
+  "Indicators used to represent formatting in multi-line candidates.
+
+Currently, multi-line candidates are flattened, stripped of
+repeated whitespace, and, if need be, truncated. Additionally,
+when a multi-line candidate matches the user's input, the
+matching line is also displayed at the beginning of the
+candidate. This formatting does not affect the actual value of a
+candidate.
 
 When customizing this option, all indicators must be present in
 the list. They are \"match\", \"truncation\", \"newline\", and
 \"whitespace\".
 
 There are two values that make a transformation:
-1. A string to indicate the display change, such as \"..\", which
+1. A string to indicate the display change, such as `\"..\"', which
    replaces repeated whitespace.
-2. A face with which to display the indicator, such as `shadow'.
+2. A face to assign to the indicator string, such as `shadow'.
 
-In this way, a setting is represented, e.g., as
+Therefore, a setting is represented, e.g., as
 `(whitespace \"..\" shadow)'."
   :type '(repeat (list :tag "Display settings"
                        (choice (const :tag "Matching line"
@@ -862,7 +864,12 @@ currently displayed candidates."
 
 (defun selectrum--ensure-single-lines (candidates)
   "Return list of single line CANDIDATES.
-Multi-line canidates are merged into a single line."
+Multi-line candidates are merged into a single line. The resulting
+single-line candidates are then shortened by replacing repeated
+whitespace and maybe truncating the result.
+
+These changes are indicated by strings defined in
+`selectrum-multiline-display-settings'."
   (let* ((single/lines ())
 
          ;; The indicators are the same for all multi-line candidates, and so

--- a/selectrum.el
+++ b/selectrum.el
@@ -283,12 +283,12 @@ This option is a workaround for 2 problems:
     (truncation :indicator "..." :face shadow)
     (newline    :indicator "\\n" :face warning)
     (whitespace :indicator ".."  :face shadow))
-  "A list of indicators that Selectrum uses to represent
-transformations when formatting and displaying candidates. This
-formatting does not affect the actual value of a candidate. By
-default, multi-line candidates are flattened, long candidates are
-truncated, repeated whitespace is shortened, and the matching
-line in a multi-line candidate is displayed at the front.
+  "Indicators used to represent transformations in displayed candidates.
+This formatting does not affect the actual value of a candidate.
+By default, in the case of multi-line candidates, said candidates
+are flattened, long candidates are truncated, repeated whitespace
+is shortened, and the matching line in a multi-line candidate is
+displayed at the front.
 
 These values affect the behavior of `selectrum--ensure-single-lines',
 which does the formatting by replacing the found pattern (except

--- a/selectrum.el
+++ b/selectrum.el
@@ -870,20 +870,28 @@ Multi-line canidates are merged into a single line."
          ;; once.
          (selectrum--match-transformation
           (alist-get 'match selectrum-multiline-display-settings))
-         (selectrum--match-display (car selectrum--match-transformation))
-         (selectrum--match-face (cadr selectrum--match-transformation))
+         (selectrum--match-display
+          (car selectrum--match-transformation))
+         (selectrum--match-face
+          (cadr selectrum--match-transformation))
          (selectrum--truncation-transformation
           (alist-get 'truncation selectrum-multiline-display-settings))
-         (selectrum--truncation-display (car selectrum--truncation-transformation))
-         (selectrum--truncation-face (cadr selectrum--truncation-transformation))
+         (selectrum--truncation-display
+          (car selectrum--truncation-transformation))
+         (selectrum--truncation-face
+          (cadr selectrum--truncation-transformation))
          (selectrum--newline-transformation
           (alist-get 'newline selectrum-multiline-display-settings))
-         (selectrum--newline-display (car selectrum--newline-transformation))
-         (selectrum--newline-face (cadr selectrum--newline-transformation))
+         (selectrum--newline-display
+          (car selectrum--newline-transformation))
+         (selectrum--newline-face
+          (cadr selectrum--newline-transformation))
          (selectrum--whitespace-transformation
           (alist-get 'whitespace selectrum-multiline-display-settings))
-         (selectrum--whitespace-display (car selectrum--whitespace-transformation))
-         (selectrum--whitespace-face (cadr selectrum--whitespace-transformation)))
+         (selectrum--whitespace-display
+          (car selectrum--whitespace-transformation))
+         (selectrum--whitespace-face
+          (cadr selectrum--whitespace-transformation)))
 
     (dolist (cand candidates (nreverse single-line-candidates))
       (push

--- a/selectrum.el
+++ b/selectrum.el
@@ -283,7 +283,25 @@ This option is a workaround for 2 problems:
     (truncation :indicator "..."   :face shadow)
     (newline    :indicator "\\\\n" :face warning)
     (whitespace :indicator ".."    :face shadow))
-  "Transformation indicators.")
+  "A list of indicators that Selectrum uses to represent
+transformations when formatting and displaying candidates. This
+formatting does not affect the actual value of a candidate. By
+default, multi-line candidates are flattened, long candidates are
+truncated, repeated whitespace is shortened, and the matching
+line in a multi-line candidate is displayed at the front.
+
+These values affect the behavior of `selectrum--ensure-single-lines',
+which does the formatting by replacing the found pattern (except
+for indicating a match, in which case the indicator is inserted
+between the matched line and the candidate).
+
+There are two values that make a transformation:
+1. A string to indicate the display change, such as \"..\", which
+   replaces repeated whitespace.
+2. A face with which to display the indicator, such as `shadow'.
+
+In this way, a transformation is represented, e.g., as
+`(whitespace :indicator \"..\" :face shadow)'.")
 
 ;;;; Utility functions
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -873,18 +873,19 @@ currently displayed candidates."
              win (- dheight wheight) nil nil 'pixelwise)))))))
 
 (defun selectrum--ensure-single-lines (candidates)
-  "Return list of single line CANDIDATES.
+  "Return list of single-line CANDIDATES.
 Multi-line candidates are merged into a single line. The resulting
 single-line candidates are then shortened by replacing repeated
 whitespace and maybe truncating the result.
 
-These changes are indicated by strings defined in
+The specific details of the formatting are determined by
 `selectrum-multiline-display-settings'."
   (let* ((single/lines ())
 
-         ;; The indicators are the same for all multi-line candidates, and so
-         ;; only need to be gotten from `selectrum-multiline-display-settings'
-         ;; once.
+         ;; The formatting settings are the same for all multi-line
+         ;; candidates, and so only need to be gotten once from
+         ;; `selectrum-multiline-display-settings'.
+         ;;
          ;; - Matching lines
          (match/transformation
           (alist-get 'match selectrum-multiline-display-settings))

--- a/selectrum.el
+++ b/selectrum.el
@@ -856,18 +856,17 @@ Multi-line canidates are merged into a single line."
              (concat (unless (string-empty-p (minibuffer-contents))
                        ;; Show first matched line.
                        (when-let ((match
-                                   (car
-                                    (funcall
-                                     selectrum-refine-candidates-function
-                                     (minibuffer-contents)
-                                     (split-string cand "\n")))))
+                                   (car (funcall
+                                         selectrum-refine-candidates-function
+                                         (minibuffer-contents)
+                                         (split-string cand "\n")))))
                          (concat match
                                  (propertize match-display 'face match-face))))
                      (if (< (length cand) 1000)
                          cand
                        (concat
                         (substring cand 0 1000)
-                        (propertize "..." 'face 'warning))))
+                        (propertize truncation-display 'face truncation-face))))
              ;; Replacements should be fixed-case and literal, to make things
              ;; simpler.
              t t)


### PR DESCRIPTION
I think it makes sense to be able to customize these settings. These are the options made:
- selectrum-horizontal-whitespace-indicator: ".."
- selectrum-matching-line-indicator:         " -> "
- selectrum-newline-indicator:               "\\\\n"
- selectrum-truncated-candidate-indicator:   "..."

Should the faces applied to the strings also be customizable?