### PR TITLE
Fix selectrum-insert-current-candidate error when history is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ The format is based on [Keep a Changelog].
   `completing-read-multiple` when `crm-separator` has a non default
   value. Previously it would replace the separator with commas when
   adding new candidates ([#140]).
+* `selectrum-insert-current-candidate` now works from
+  `selectrum-select-from-history` and other commands which ignore
+  history by setting `minibuffer-history-variable` to `t`. Previously
+  an error would be thrown ([#152]).
 
 [#67]: https://github.com/raxod502/selectrum/issues/67
 [#82]: https://github.com/raxod502/selectrum/issues/82
@@ -112,6 +116,7 @@ The format is based on [Keep a Changelog].
 [#133]: https://github.com/raxod502/selectrum/pull/133
 [#138]: https://github.com/raxod502/selectrum/pull/138
 [#140]: https://github.com/raxod502/selectrum/pull/140
+[#152]: https://github.com/raxod502/selectrum/pull/152
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1140,7 +1140,8 @@ list). A null or non-positive ARG inserts the candidate corresponding to
                            selectrum--refined-candidates))
            (full (selectrum--get-full candidate)))
       (insert full)
-      (add-to-history minibuffer-history-variable full)
+      (unless (eq t minibuffer-history-variable)
+        (add-to-history minibuffer-history-variable full))
       (apply
        #'run-hook-with-args
        'selectrum-candidate-inserted-hook


### PR DESCRIPTION
`add-to-history` errors when `minibuffer-history-variable` is `t` (which indicates history should be ignored). This meant  `selectrum-insert-current-candidate` would error when called from `selectrum-select-from-history`.

