### PR TITLE
Update minibuffer height according to text height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ The format is based on [Keep a Changelog].
     visible when it can be submitted (similar to the effect of
     `minibuffer-electric-default-mode`).
   * The default candidate shown in the prompt message is now displayed
-    with the face `selectrum-current-candidate` when it is selected.51
+    with the face `selectrum-current-candidate` when it is selected.
   * Now that Selectrum always shows the default candidate when it can
     be submitted, it now attempts to remove the default candidate from
     prompt messages that already contain it. This decreases
@@ -67,14 +67,18 @@ The format is based on [Keep a Changelog].
   assumed that the minibuffer only contains user input would be likely
   to fail ([#124]). This also means inside the minibuffer
   `minibuffer-contents` now returns only the current input as expected
-  ([#116], [#133]). In order to avoid wrong minibuffer heights
-  `line-spacing` got disabled for Selectrum sessions ([#151], [#154]).
+  ([#116], [#133]).
 * Multiline candidates are now merged into a single truncated line so
   there is no gradual scrolling effect anymore when going through the
   candidate list. The first matched line is shown in front of the
   merged lines ([#133]).
 
 ### Bugs fixed
+* The mininbuffer height is now determined by the actual height of
+  displayed candidates. Previously the height could be off for
+  candidates containing unicode characters or other means which
+  changed the display height such as `line-spacing` ([#146], [#151],
+  [#154]).
 * Incremental history search via `isearch` wasn't working which has
   been fixed ([#124], [#133]).
 * Empty string completion candidates are now ignored like in the
@@ -113,6 +117,7 @@ The format is based on [Keep a Changelog].
 [#133]: https://github.com/raxod502/selectrum/pull/133
 [#138]: https://github.com/raxod502/selectrum/pull/138
 [#140]: https://github.com/raxod502/selectrum/pull/140
+[#146]: https://github.com/raxod502/selectrum/issues/146
 [#151]: https://github.com/raxod502/selectrum/issues/151
 [#154]: https://github.com/raxod502/selectrum/pull/154
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ The format is based on [Keep a Changelog].
     visible when it can be submitted (similar to the effect of
     `minibuffer-electric-default-mode`).
   * The default candidate shown in the prompt message is now displayed
-    with the face `selectrum-current-candidate` when it is selected.
+    with the face `selectrum-current-candidate` when it is selected.51
   * Now that Selectrum always shows the default candidate when it can
     be submitted, it now attempts to remove the default candidate from
     prompt messages that already contain it. This decreases
@@ -67,7 +67,8 @@ The format is based on [Keep a Changelog].
   assumed that the minibuffer only contains user input would be likely
   to fail ([#124]). This also means inside the minibuffer
   `minibuffer-contents` now returns only the current input as expected
-  ([#116], [#133]).
+  ([#116], [#133]). In order to avoid wrong minibuffer heights
+  `line-spacing` got disabled for Selectrum sessions ([#151], [#154]).
 * Multiline candidates are now merged into a single truncated line so
   there is no gradual scrolling effect anymore when going through the
   candidate list. The first matched line is shown in front of the
@@ -112,6 +113,8 @@ The format is based on [Keep a Changelog].
 [#133]: https://github.com/raxod502/selectrum/pull/133
 [#138]: https://github.com/raxod502/selectrum/pull/138
 [#140]: https://github.com/raxod502/selectrum/pull/140
+[#151]: https://github.com/raxod502/selectrum/issues/151
+[#154]: https://github.com/raxod502/selectrum/pull/154
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -804,20 +804,20 @@ currently displayed candidates."
   (let ((n (1+ selectrum-num-candidates-displayed))
         (win (active-minibuffer-window)))
     (when (and win
-               ;; don't try to resize a minibuffer frame
+               ;; Don't try to resize a minibuffer frame.
                (not (frame-root-window-p win)))
       ;; Set min initial height.
       (when (and selectrum-fix-minibuffer-height
                  selectrum--init-p)
         (with-selected-window win
           (setf (window-height) n)))
-      ;; Adjust if needed
+      ;; Adjust if needed.
       (when (or selectrum--init-p
                 (and selectrum--current-candidate-index
                      ;; Allow size change when navigating, not while
                      ;; typing.
                      (/= first highlighted)
-                     ;; Don't allow shrink for less candidates.
+                     ;; Don't allow shrinking.
                      (= (length cands)
                         selectrum-num-candidates-displayed)))
         (let ((dheight (cdr (window-text-pixel-size win)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -801,15 +801,16 @@ FIRST is the index of the first displayed candidate."
                selectrum--init-p)
       (with-selected-window win
         (setf (window-height) n)))
-    ;; Grow if needed.
+    ;; Adjust if needed
     (when (or selectrum--init-p
-              ;; Don't allow growing while typing.
+              ;; Allow size change when navigating but not while
+              ;; typing.
               (and selectrum--current-candidate-index
                    (/= selectrum--current-candidate-index
                        first)))
       (let ((dheight (cdr (window-text-pixel-size win)))
             (wheight (window-pixel-height win)))
-        (when (> dheight wheight)
+        (when (/= dheight wheight)
           (window-resize
            win (- dheight wheight) nil nil 'pixelwise))))))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -783,7 +783,9 @@ PRED defaults to `minibuffer-completion-predicate'."
         (setq text (concat (or default " ") text))
         (put-text-property 0 1 'cursor t text)
         (overlay-put selectrum--candidates-overlay 'after-string text))
-      (selectrum--update-minibuffer-height first-index-displayed))
+      (selectrum--update-minibuffer-height first-index-displayed
+                                           highlighted-index
+                                           displayed-candidates))
     (setq selectrum--end-of-input-marker (set-marker (make-marker) bound))
     (set-marker-insertion-type selectrum--end-of-input-marker t)
     (selectrum--fix-set-minibuffer-message)
@@ -791,9 +793,11 @@ PRED defaults to `minibuffer-completion-predicate'."
       (setq deactivate-mark nil))
     (setq-local selectrum--init-p nil)))
 
-(defun selectrum--update-minibuffer-height (first)
+(defun selectrum--update-minibuffer-height (first highlighted cands)
   "Set minibuffer height for candidates display.
-FIRST is the index of the first displayed candidate."
+FIRST is the index of the first displayed candidate. HIGHLIGHTED
+is the index if the highlighted candidate. CANDS are the
+currently displayed candidates."
   (let ((n (1+ selectrum-num-candidates-displayed))
         (win (active-minibuffer-window)))
     ;; Set min initial height.
@@ -806,8 +810,9 @@ FIRST is the index of the first displayed candidate."
               ;; Allow size change when navigating but not while
               ;; typing.
               (and selectrum--current-candidate-index
-                   (/= selectrum--current-candidate-index
-                       first)))
+                   (/= first highlighted)
+                   (>= (length cands)
+                       selectrum-num-candidates-displayed)))
       (let ((dheight (cdr (window-text-pixel-size win)))
             (wheight (window-pixel-height win)))
         (when (/= dheight wheight)

--- a/selectrum.el
+++ b/selectrum.el
@@ -801,11 +801,10 @@ PRED defaults to `minibuffer-completion-predicate'."
 FIRST is the index of the first displayed candidate. HIGHLIGHTED
 is the index if the highlighted candidate. CANDS are the
 currently displayed candidates."
-  (let ((n (1+ selectrum-num-candidates-displayed))
-        (win (active-minibuffer-window)))
-    (when (and win
-               ;; Don't try to resize a minibuffer frame.
-               (not (frame-root-window-p win)))
+  (when-let ((n (1+ selectrum-num-candidates-displayed))
+             (win (active-minibuffer-window)))
+    ;; Don't attempt to resize a minibuffer frame.
+    (unless (frame-root-window-p win)
       ;; Set min initial height.
       (when (and selectrum-fix-minibuffer-height
                  selectrum--init-p)

--- a/selectrum.el
+++ b/selectrum.el
@@ -803,25 +803,28 @@ is the index if the highlighted candidate. CANDS are the
 currently displayed candidates."
   (let ((n (1+ selectrum-num-candidates-displayed))
         (win (active-minibuffer-window)))
-    ;; Set min initial height.
-    (when (and selectrum-fix-minibuffer-height
-               selectrum--init-p)
-      (with-selected-window win
-        (setf (window-height) n)))
-    ;; Adjust if needed
-    (when (or selectrum--init-p
-              (and selectrum--current-candidate-index
-                   ;; Allow size change when navigating, not while
-                   ;; typing.
-                   (/= first highlighted)
-                   ;; Don't allow shrink for less candidates.
-                   (= (length cands)
-                      selectrum-num-candidates-displayed)))
-      (let ((dheight (cdr (window-text-pixel-size win)))
-            (wheight (window-pixel-height win)))
-        (when (/= dheight wheight)
-          (window-resize
-           win (- dheight wheight) nil nil 'pixelwise))))))
+    (when (and win
+               ;; don't try to resize a minibuffer frame
+               (not (frame-root-window-p win)))
+      ;; Set min initial height.
+      (when (and selectrum-fix-minibuffer-height
+                 selectrum--init-p)
+        (with-selected-window win
+          (setf (window-height) n)))
+      ;; Adjust if needed
+      (when (or selectrum--init-p
+                (and selectrum--current-candidate-index
+                     ;; Allow size change when navigating, not while
+                     ;; typing.
+                     (/= first highlighted)
+                     ;; Don't allow shrink for less candidates.
+                     (= (length cands)
+                        selectrum-num-candidates-displayed)))
+        (let ((dheight (cdr (window-text-pixel-size win)))
+              (wheight (window-pixel-height win)))
+          (when (/= dheight wheight)
+            (window-resize
+             win (- dheight wheight) nil nil 'pixelwise)))))))
 
 (defun selectrum--first-lines (candidates)
   "Return list of single line CANDIDATES.

--- a/selectrum.el
+++ b/selectrum.el
@@ -807,12 +807,13 @@ currently displayed candidates."
         (setf (window-height) n)))
     ;; Adjust if needed
     (when (or selectrum--init-p
-              ;; Allow size change when navigating but not while
-              ;; typing.
               (and selectrum--current-candidate-index
+                   ;; Allow size change when navigating, not while
+                   ;; typing.
                    (/= first highlighted)
-                   (>= (length cands)
-                       selectrum-num-candidates-displayed)))
+                   ;; Don't allow shrink for less candidates.
+                   (= (length cands)
+                      selectrum-num-candidates-displayed)))
       (let ((dheight (cdr (window-text-pixel-size win)))
             (wheight (window-pixel-height win)))
         (when (/= dheight wheight)

--- a/selectrum.el
+++ b/selectrum.el
@@ -958,6 +958,9 @@ CANDIDATES is the list of strings that was passed to
 `selectrum-read'. DEFAULT-CANDIDATE, if provided, is added to the
 list and sorted first. INITIAL-INPUT, if provided, is inserted
 into the user input area to start with."
+  ;; Avoid wrong minibuffer height. Minibuffer height is currently
+  ;; determined by amount of lines and not actual display height.
+  (setq-local line-spacing nil)
   (add-hook
    'minibuffer-exit-hook #'selectrum--minibuffer-exit-hook nil 'local)
   (setq-local selectrum--init-p t)


### PR DESCRIPTION
This aims to fix #151 and #146. I also fixed the problem that each minibuffer invocation created a fresh overlay while we should better reuse the old one.