### PR TITLE
Avoid modifying candidates of dynamic collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ The format is based on [Keep a Changelog].
   merged lines ([#133]).
 
 ### Bugs fixed
+* Dynamic collection functions can now reuse their returned
+  candidates. Previously Selectrum could modify them even when the
+  `:may-modify-candidates` argument wasn't passed to `selectrum-read`.
 * Incremental history search via `isearch` wasn't working which has
   been fixed ([#124], [#133]).
 * Empty string completion candidates are now ignored like in the

--- a/selectrum.el
+++ b/selectrum.el
@@ -657,7 +657,11 @@ PRED defaults to `minibuffer-completion-predicate'."
                                     (setq input (or (alist-get 'input result)
                                                     input))
                                     (setq selectrum--visual-input input)
-                                    (alist-get 'candidates result))))
+                                    ;; Avoid modifying the returned
+                                    ;; candidates to let the function
+                                    ;; reuse them.
+                                    (copy-sequence
+                                     (alist-get 'candidates result)))) )
                      selectrum--preprocessed-candidates)))
         (setq selectrum--total-num-candidates (length cands))
         (setq selectrum--refined-candidates


### PR DESCRIPTION
This fixes #90. Currently this doesn't try to use the opportunity to modify the candidates when `:may-modify-candidates` is set because I think usually the performance benefit should be small for dynamic collections.