### PR TITLE
Add selectrum--completing-read-handler-alist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,10 +74,11 @@ The format is based on [Keep a Changelog].
   merged lines ([#133]).
 
 ### Bugs fixed
-* Commands which used `locate-file-completion-table` such as
-  `load-library`, `locate-library` and `finder-commentary` would
-  display duplicates and included directories which has been fixed.
-  They also correctly handle load path shadows like `find-library` now
+* Commands which used `locate-file-completion-table` to locate
+  libraries such as `load-library`, `locate-library` and
+  `finder-commentary` would display duplicates and included
+  directories which has been fixed. They also correctly handle load
+  path shadows now like commands which use `read-library-name`
   ([#136], [#156]).
 * `org-set-tags-command` completion wasn't working after the first
   inserted tag which has been fixed ([#139], [#156]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ The format is based on [Keep a Changelog].
   merged lines ([#133]).
 
 ### Bugs fixed
+* Commands which used `locate-file-completion-table` such as
+  `load-library`, `locate-library` and `finder-commentary` would
+  display duplicates and included directories which has been fixed
+  ([#136], [#156]).
+* `org-set-tags-command` completion wasn't working after the first
+  inserted tag which has been fixed ([#139], [#156]).
 * Incremental history search via `isearch` wasn't working which has
   been fixed ([#124], [#133]).
 * Empty string completion candidates are now ignored like in the
@@ -110,8 +116,11 @@ The format is based on [Keep a Changelog].
 [#130]: https://github.com/raxod502/selectrum/issues/130
 [#132]: https://github.com/raxod502/selectrum/pull/132
 [#133]: https://github.com/raxod502/selectrum/pull/133
+[#136]: https://github.com/raxod502/selectrum/issues/136
 [#138]: https://github.com/raxod502/selectrum/pull/138
+[#139]: https://github.com/raxod502/selectrum/issues/139
 [#140]: https://github.com/raxod502/selectrum/pull/140
+[#156]: https://github.com/raxod502/selectrum/pull/156
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,19 +156,16 @@ The format is based on [Keep a Changelog].
 [#138]: https://github.com/raxod502/selectrum/pull/138
 [#139]: https://github.com/raxod502/selectrum/issues/139
 [#140]: https://github.com/raxod502/selectrum/pull/140
-<<<<<<< HEAD
-[#156]: https://github.com/raxod502/selectrum/pull/156
-=======
 [#146]: https://github.com/raxod502/selectrum/issues/146
 [#151]: https://github.com/raxod502/selectrum/issues/151
 [#152]: https://github.com/raxod502/selectrum/pull/152
 [#154]: https://github.com/raxod502/selectrum/pull/154
+[#156]: https://github.com/raxod502/selectrum/pull/156
 [#157]: https://github.com/raxod502/selectrum/issues/157
 [#159]: https://github.com/raxod502/selectrum/issues/159
 [#160]: https://github.com/raxod502/selectrum/pull/160
 [#161]: https://github.com/raxod502/selectrum/pull/161
 [#163]: https://github.com/raxod502/selectrum/pull/163
->>>>>>> master
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,8 @@ The format is based on [Keep a Changelog].
 ### Bugs fixed
 * Commands which used `locate-file-completion-table` such as
   `load-library`, `locate-library` and `finder-commentary` would
-  display duplicates and included directories which has been fixed
+  display duplicates and included directories which has been fixed.
+  They also correctly handle load path shadows like `find-library` now
   ([#136], [#156]).
 * `org-set-tags-command` completion wasn't working after the first
   inserted tag which has been fixed ([#139], [#156]).

--- a/selectrum.el
+++ b/selectrum.el
@@ -1762,6 +1762,7 @@ For large enough N, return PATH unchanged."
       (match-string 0 path))))
 
 (defun selectrum--locate-library-completions ()
+  "Get list of candidates for library completions."
   (eval-and-compile
     (require 'find-func))
   (let ((suffix-regexp (concat (regexp-opt (find-library-suffixes)) "\\'"))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1352,7 +1352,13 @@ The values are plists using the following keys:
 
   A function to transform the completion table. Receives the
   original completion table and completion predicate. Should
-  return a completion table which should be used instead.
+  return a completion table which should be used instead. If
+  passed a completion function the transformer should also return
+  a completion function so the table doesn't get initialized
+  before `selectrum--minibuffer-post-command-hook' runs. This can
+  be useful when one wants to skip the initial computation of the
+  table. With `completing-read-default' the computation happens
+  only after pressing TAB and this allows to mimic this behavior.
 
 :handler
 
@@ -1373,13 +1379,14 @@ The symbol is used to identify COLLECTION in
 (defun selectrum--locate-file-completion-transformer (collection pred)
   "Remove duplicates and directories from COLLECTION.
 PRED is the completion predicate."
-  (delete-dups
-   (funcall collection ""
-            (lambda (cand)
-              (and (not (string-match "/\\'" cand))
-                   (or (not pred)
-                       (funcall pred cand))))
-            t)))
+  (lambda (_string _pred _flag)
+    (delete-dups
+     (funcall collection ""
+              (lambda (cand)
+                (and (not (string-match "/\\'" cand))
+                     (or (not pred)
+                         (funcall pred cand))))
+              t))))
 
 (defvar org-last-tags-completion-table)
 (defun selectrum--org-tags-completion-transformer (_collection _pred)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1350,7 +1350,7 @@ The values are plists using the following keys:
 
 :transformer:
 
-  A function to transform the completion table. Reveives the
+  A function to transform the completion table. Receives the
   original completion table and completion predicate. Should
   return a completion table which should be used instead.
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -1412,7 +1412,7 @@ COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT, HIST, DEF,
 and INHERIT-INPUT-METHOD, see `completing-read'."
   (let ((crm-separator ":\\|,\\|\\s-"))
     (mapconcat #'identity
-               (completing-read-multiple
+               (selectrum-completing-read-multiple
                 prompt collection predicate nil
                 initial-input hist def inherit-input-method)
                ":")))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1376,8 +1376,7 @@ The symbol is used to identify COLLECTION in
   (cond ((and (memq real-this-command
                     '(load-library
                       locate-library
-                      finder-commentary
-                      find-library))
+                      finder-commentary))
               (byte-code-function-p collection)
               (ignore-errors
                 (eq 'locate-file-completion-table

--- a/selectrum.el
+++ b/selectrum.el
@@ -1348,17 +1348,17 @@ in the case the table isn't a named function.
 
 The values are plists using the following keys:
 
-:transformer:
+:transformer
 
   A function to transform the completion table. Receives the
   original completion table and completion predicate. Should
   return a completion table which should be used instead.
 
-:handler:
+:handler
 
   A function to be used as `completing-read-function' for the
   table. This handler gets passed the original table or the
-  result of :transformer: if specified.")
+  result of :transformer if specified.")
 
 (defun selectrum--get-collection-name (collection)
   "Get symbol for completion COLLECTION.

--- a/selectrum.el
+++ b/selectrum.el
@@ -1756,15 +1756,13 @@ For large enough N, return PATH unchanged."
       (string-match regexp path)
       (match-string 0 path))))
 
-(defun selectrum--locate-library-completions (&optional suffixes)
+(defun selectrum--locate-library-completions ()
   "Get list of candidates for library completions.
 SUFFIXES defaults to the value returned by
 `find-library-suffixes'."
   (eval-and-compile
     (require 'find-func))
-  (let ((suffix-regexp (concat (regexp-opt
-                                (or suffixes
-                                    (find-library-suffixes))) "\\'"))
+  (let ((suffix-regexp (concat (regexp-opt (find-library-suffixes)) "\\'"))
         (table (make-hash-table :test #'equal))
         (lst nil))
     (dolist (dir (or find-function-source-path load-path))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1957,9 +1957,9 @@ ARGS are standard as in all `:around' advice."
       ;; No sharp quote because Dired may not be loaded yet.
       (advice-remove 'dired-read-dir-and-switches
                      #'selectrum--fix-dired-read-dir-and-switches)
-      ;; No sharp quote because `read-library-name' is not defined
-      ;; in older Emacs versions.
-      (advice-add 'read-library-name :override #'selectrum-read-library-name)
+      ;; No sharp quote because `read-library-name' is not defined in
+      ;; older Emacs versions.
+      (advice-remove 'read-library-name #'selectrum-read-library-name)
       (advice-remove #'minibuffer-message #'selectrum--fix-minibuffer-message)
       ;; No sharp quote because `set-minibuffer-message' is not
       ;; defined in older Emacs versions.


### PR DESCRIPTION
This addresses #136 and #139 by adding the discussed `selectrum--completing-read-handler-alist`. Later we could also use this variable to solve #114 where you had the idea to have a customizable list of table symbols that are known to be static.

As discovered in #136 other commands which locate libs suffer from the same issue (for Emacs version < 28). I refactored the code to reuse the code of `read-library-name` and delegate all those commands to the function which handles shadows in load path correctly. One downside is that currently the different suffixes passed to `locate-file-completion-table` are ignored (simply passing them to `selectrum--locate-library-completions` doesn't work) and so the commands don't differentiate bettween `.el`, `.el.gz` and `.elc`. But before you couldn't either so removing the duplicates and showing load path shadows instead is an improvement. Except for `load-library` where you might want to differentiate between `.el` and `.elc` the variants make not much sense to me anyway.

The problem with the completion table seems to be that it doesn't return all those candidates at once. With default completion `.elc` and `.gz` variants are only shown after you have already completed to the library name you want and invoke completion again. 