### PR TITLE
Add selectrum--skip-updates-p to allow skipping post-command-hook computations

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -542,10 +542,12 @@ candidates as per `selectrum-candidate-full' text property."
 
 (defun selectrum-set-selected-candidate (&optional string)
   "Set currently selected candidate to STRING.
-STRING defaults to `minibuffer-contents'. This function skips
-recomputation of candidates. This is useful for injecting a
-candidate in `minibuffer-setup-hook' and immediately exit with it
-afterwards."
+STRING defaults to `minibuffer-contents'. Computation of
+candidates is skipped from there on. This is useful for injecting
+a candidate in `minibuffer-setup-hook' and immediately exit with
+it afterwards. With default completion there is no computation
+triggered initially and this function can be used to mimic this
+behavior."
   (when selectrum-active-p
     (with-selected-window (active-minibuffer-window)
       (let ((string (or string (minibuffer-contents))))

--- a/selectrum.el
+++ b/selectrum.el
@@ -497,7 +497,7 @@ This is used to implement `selectrum-repeat'.")
   "If selectrum should skip updates.
 
 In normal operation Selectrum checks for updating its UI after
-each command. When this variabele is non-nil the computation of
+each command. When this variable is non-nil the computation of
 updates is skipped.")
 
 (defvar-local selectrum--init-p nil


### PR DESCRIPTION
Usually the hook won't run when selectrum-active-p is nil but it is an extra guard and also make it easy to skip the hook entirely by `selectrum-set-selected-candidate` and other code which wants to stop automatic updates of selectrum.