### PR TITLE
Fix prompt selection issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ The format is based on [Keep a Changelog].
   passed to `selectrum-read-file-name` which is the behavior of
   default completion where there is no concept of an active selection
   ([#157], [#160]).
+* When there are no candidates and a match isn't required the prompt
+  will be shown as selected to indicate one can submit the input
+  ([#160]).
 * `icomplete-mode` is now automatically disabled when entering
   Selectrum, to avoid conflicts ([#99]).
 * Working with the default candidate has been improved in cases where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ The format is based on [Keep a Changelog].
   [#113] and [#118].
 
 ### Enhancements
+* If the `default-filename` passed to `selectrum-read-file-name` is an
+  absolute path it will still be sorted to the top when it is
+  contained in the prompting directory ([#160]).
+* When selecting file name prompts and submitting them the result will
+  be the selected prompt. Previously it could be the default file name
+  passed to `selectrum-read-file-name` which is the behavior of
+  default completion where there is no concept of an active selection
+  ([#157], [#160]).
 * `icomplete-mode` is now automatically disabled when entering
   Selectrum, to avoid conflicts ([#99]).
 * Working with the default candidate has been improved in cases where
@@ -74,6 +82,9 @@ The format is based on [Keep a Changelog].
   merged lines ([#133]).
 
 ### Bugs fixed
+* If the `mustmatch` argument to `read-directory-name` was non-nil the
+  selection of the prompt wasn't visible which has been fixed ([#157],
+  [#160]).
 * If a predicate was passed to `read-buffer` an error would be thrown
   which has been fixed ([#159], [#161]).
 * Dynamic collection functions can now reuse their returned
@@ -122,7 +133,9 @@ The format is based on [Keep a Changelog].
 [#138]: https://github.com/raxod502/selectrum/pull/138
 [#140]: https://github.com/raxod502/selectrum/pull/140
 [#152]: https://github.com/raxod502/selectrum/pull/152
+[#157]: https://github.com/raxod502/selectrum/issues/157
 [#159]: https://github.com/raxod502/selectrum/issues/159
+[#160]: https://github.com/raxod502/selectrum/pull/160
 [#161]: https://github.com/raxod502/selectrum/pull/161
 
 ## 2.0 (released 2020-07-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,14 +38,6 @@ The format is based on [Keep a Changelog].
 * If the `default-filename` passed to `selectrum-read-file-name` is an
   absolute path it will still be sorted to the top when it is
   contained in the prompting directory ([#160]).
-* When selecting file name prompts and submitting them the result will
-  be the selected prompt. Previously it could be the default file name
-  passed to `selectrum-read-file-name` which is the behavior of
-  default completion where there is no concept of an active selection
-  ([#157], [#160]).
-* When there are no candidates and a match isn't required the prompt
-  will be shown as selected to indicate one can submit the input
-  ([#160]).
 * `icomplete-mode` is now automatically disabled when entering
   Selectrum, to avoid conflicts ([#99]).
 * Working with the default candidate has been improved in cases where
@@ -85,6 +77,14 @@ The format is based on [Keep a Changelog].
   merged lines ([#133]).
 
 ### Bugs fixed
+* When selecting file name prompts and submitting them the result will
+  be the selected prompt. Previously it could be the default file name
+  passed to `selectrum-read-file-name` which is the behavior of
+  default completion where there is no concept of an active selection
+  ([#157], [#160]).
+* When there are no candidates and a match isn't required the prompt
+  will now be shown as selected to indicate one can submit the input
+  ([#160]).
 * If the `mustmatch` argument to `read-directory-name` was non-nil the
   selection of the prompt wasn't visible which has been fixed ([#157],
   [#160]).

--- a/selectrum.el
+++ b/selectrum.el
@@ -1617,8 +1617,8 @@ PREDICATE, see `read-file-name'."
                            ;; Sort for directories needs any final
                            ;; slash removed.
                            (directory-file-name
-                            ;; The candidates are sorted by their
-                            ;; relative names.
+                            ;; The candidate should be sorted by it's
+                            ;; relative name.
                             (file-relative-name default-filename
                                                 default-directory))))
                    (set-syntax-table
@@ -1627,16 +1627,17 @@ PREDICATE, see `read-file-name'."
        prompt dir
        ;; We don't pass default-candidate here to avoid that
        ;; submitting the selected prompt results in the default file
-       ;; name. Instead we pass the initial prompt as default so it
-       ;; gets returned when submitted. In addition to that we set
-       ;; `selectrum--default-candidate' in the setup hook above so
-       ;; the actual default gets sorted to the top. This should give
-       ;; the same convenience as in default completion (where you can
-       ;; press RET at the initial prompt to get the default). The
-       ;; downside is that this convenience is gone when sorting is
-       ;; disabled or the default-filename is outside the prompting
-       ;; directory but this should be rare and seems to be a weird
-       ;; case for default completion as well.
+       ;; name. This is the stock Emacs behavior where there is no
+       ;; concept of an active selection. Instead we pass the initial
+       ;; prompt as default so it gets returned when submitted. In
+       ;; addition to that we set `selectrum--default-candidate' in
+       ;; the setup hook above so the actual default gets sorted to
+       ;; the top. This should give the same convenience as in default
+       ;; completion (where you can press RET at the initial prompt to
+       ;; get the default). The downside is that this convenience is
+       ;; gone when sorting is disabled or the default-filename is
+       ;; outside the prompting directory but this should be rare
+       ;; case.
        (concat
         (or dir default-directory)
         initial)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1613,7 +1613,7 @@ PREDICATE, see `read-file-name'."
                               ;; ./ should be omitted.
                               (not (equal
                                     (expand-file-name default-filename)
-                                    default-directory)))
+                                    (expand-file-name default-directory))))
                      (setq selectrum--default-candidate
                            ;; Sort for directories needs any final
                            ;; slash removed.
@@ -1640,8 +1640,9 @@ PREDICATE, see `read-file-name'."
        ;; outside the prompting directory but this should be rare
        ;; case.
        (concat
-        (or (and dir (expand-file-name dir))
-            default-directory)
+        (expand-file-name
+         (or dir
+             default-directory))
         initial)
        mustmatch initial predicate))))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -686,7 +686,8 @@ PRED defaults to `minibuffer-completion-predicate'."
         (setq selectrum--current-candidate-index
               (cond
                ((null selectrum--refined-candidates)
-                nil)
+                (when (not selectrum--match-required-p)
+                  -1))
                ((and selectrum--default-candidate
                      (string-empty-p (minibuffer-contents))
                      (not (member selectrum--default-candidate

--- a/selectrum.el
+++ b/selectrum.el
@@ -1606,6 +1606,7 @@ PREDICATE, see `read-file-name'."
     (minibuffer-with-setup-hook
         (:append (lambda ()
                    (when (and default-filename
+                              ;; ./ should be omitted.
                               (not (equal
                                     (expand-file-name default-filename)
                                     (expand-file-name default-directory))))
@@ -1623,15 +1624,19 @@ PREDICATE, see `read-file-name'."
        prompt dir
        ;; We don't pass default-candidate here to avoid that
        ;; submitting the selected prompt results in the default file
-       ;; name. Instead we set `selectrum--default-candidate' in the
-       ;; setup hook above so it gets sorted to the top. This gives
-       ;; the same convenience as in default completion (where you
-       ;; press RET at the prompt to get the default). The downside is
-       ;; that this convenience is gone when sorting is disabled or
-       ;; the default-filename is outside the prompting directory but
-       ;; this should be rare and seems to be weird for default
-       ;; completion as well.
-       (or dir default-directory)
+       ;; name. Instead we pass the initial prompt as default so it
+       ;; gets returned when submitted. In addition to that we set
+       ;; `selectrum--default-candidate' in the setup hook above so
+       ;; the actual default gets sorted to the top. This should give
+       ;; the same convenience as in default completion (where you can
+       ;; press RET at the initial prompt to get the default). The
+       ;; downside is that this convenience is gone when sorting is
+       ;; disabled or the default-filename is outside the prompting
+       ;; directory but this should be rare and seems to be a weird
+       ;; case for default completion as well.
+       (concat
+        (or dir default-directory)
+        initial)
        mustmatch initial predicate))))
 
 (defvar selectrum--old-read-file-name-function nil

--- a/selectrum.el
+++ b/selectrum.el
@@ -1613,7 +1613,7 @@ PREDICATE, see `read-file-name'."
                               ;; ./ should be omitted.
                               (not (equal
                                     (expand-file-name default-filename)
-                                    (expand-file-name default-directory))))
+                                    default-directory)))
                      (setq selectrum--default-candidate
                            ;; Sort for directories needs any final
                            ;; slash removed.
@@ -1640,7 +1640,8 @@ PREDICATE, see `read-file-name'."
        ;; outside the prompting directory but this should be rare
        ;; case.
        (concat
-        (or dir default-directory)
+        (or (and dir (expand-file-name dir))
+            default-directory)
         initial)
        mustmatch initial predicate))))
 


### PR DESCRIPTION
This fixes the problems described in #157. In addition to that it takes care of sorting the default to top when it was passed as an absolute file name. Another problem this fixes (which I discovered while working on the others) is that the prompt should be selected if there are no candidates and a match isn't required (which wasn't done before so you wouldn't know you can actually submit the input).