### PR TITLE
Fix candidate format for read-buffer predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ The format is based on [Keep a Changelog].
   merged lines ([#133]).
 
 ### Bugs fixed
+* If a predicate was passed to `read-buffer` an error would be thrown
+  which has been fixed ([#159], [#161]).
 * Dynamic collection functions can now reuse their returned
   candidates. Previously Selectrum could modify them even when the
   `:may-modify-candidates` argument wasn't passed to `selectrum-read`.
@@ -120,6 +122,8 @@ The format is based on [Keep a Changelog].
 [#138]: https://github.com/raxod502/selectrum/pull/138
 [#140]: https://github.com/raxod502/selectrum/pull/140
 [#152]: https://github.com/raxod502/selectrum/pull/152
+[#159]: https://github.com/raxod502/selectrum/issues/159
+[#161]: https://github.com/raxod502/selectrum/pull/161
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1506,28 +1506,31 @@ less appropriate. It also allows you to view hidden buffers,
 which is otherwise impossible due to tricky behavior of Emacs'
 completion machinery. For PROMPT, DEF, REQUIRE-MATCH, and
 PREDICATE, see `read-buffer'."
-  (let ((selectrum-should-sort-p nil)
-        (candidates
-         (lambda (input)
-           (let* ((buffers (mapcar #'buffer-name (buffer-list)))
-                  (candidates (if predicate
-                                  (cl-delete-if-not predicate buffers)
-                                buffers)))
-             (if (string-prefix-p " " input)
-                 (progn
-                   (setq input (substring input 1))
-                   (setq candidates
-                         (cl-delete-if-not
-                          (lambda (name)
-                            (string-prefix-p " " name))
-                          candidates)))
-               (setq candidates
-                     (cl-delete-if
-                      (lambda (name)
-                        (string-prefix-p " " name))
-                      candidates)))
-             `((candidates . ,candidates)
-               (input . ,input))))))
+  (let* ((selectrum-should-sort-p nil)
+         (buffalist (mapcar (lambda (buf)
+                              (cons (buffer-name buf) buf))
+                            (buffer-list)))
+         (buffers (mapcar #'car (if predicate
+                                    (cl-delete-if-not predicate buffalist)
+                                  buffalist)))
+         (candidates
+          (lambda (input)
+            (let ((candidates (copy-sequence buffers)))
+              (if (string-prefix-p " " input)
+                  (progn
+                    (setq input (substring input 1))
+                    (setq candidates
+                          (cl-delete-if-not
+                           (lambda (name)
+                             (string-prefix-p " " name))
+                           candidates)))
+                (setq candidates
+                      (cl-delete-if
+                       (lambda (name)
+                         (string-prefix-p " " name))
+                       candidates)))
+              `((candidates . ,candidates)
+                (input . ,input))))))
     (substring-no-properties
      (selectrum-read
       prompt candidates


### PR DESCRIPTION
This addresses #159 . The `read-buffer` predicate expects items to be a cons cell of the buffer name and the buffer object.