### PR TITLE
Refactor completing-read-function rebinding for selectrum-read-file-name

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -1635,10 +1635,11 @@ PREDICATE, see `read-file-name'."
                  (set-syntax-table
                   selectrum--minibuffer-local-filename-syntax)))
     (let* ((crf completing-read-function)
-           ;; <https://github.com/raxod502/selectrum/issues/61>. When
-           ;; you invoke another `completing-read' command recursively
-           ;; then it inherits the `completing-read-function' binding,
-           ;; and unless it's another file reading command using
+           ;; See <https://github.com/raxod502/selectrum/issues/61>.
+           ;; When you invoke another `completing-read' command
+           ;; recursively then it inherits the
+           ;; `completing-read-function' binding, and unless it's
+           ;; another file reading command using
            ;; `selectrum--completing-read-file-name' will cause an
            ;; error. To circumvent this we use the function to reset
            ;; the variable when called.

--- a/selectrum.el
+++ b/selectrum.el
@@ -1640,9 +1640,9 @@ PREDICATE, see `read-file-name'."
            ;; recursively then it inherits the
            ;; `completing-read-function' binding, and unless it's
            ;; another file reading command using
-           ;; `selectrum--completing-read-file-name' will cause an
-           ;; error. To circumvent this we use the function to reset
-           ;; the variable when called.
+           ;; `selectrum--completing-read-file-name' this will cause
+           ;; an error. To circumvent this we use the function to
+           ;; reset the variable when called.
            (completing-read-function
             (lambda (&rest args)
               (setq completing-read-function crf)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1611,11 +1611,12 @@ PREDICATE, see `read-file-name'."
                   selectrum--minibuffer-local-filename-syntax)))
     (let* ((crf completing-read-function)
            ;; <https://github.com/raxod502/selectrum/issues/61>. When
-           ;; you invoke another Selectrum command recursively then it
-           ;; inherits the `completing-read-function' binding, even if
-           ;; the new Selectrum command is not reading file names.
-           ;; This would cause an error so we use the function to
-           ;; reset the variable when called.
+           ;; you invoke another `completing-read' command recursively
+           ;; then it inherits the `completing-read-function' binding,
+           ;; and unless it's another file reading command using
+           ;; `selectrum--completing-read-file-name' will cause an
+           ;; error. To circumvent this we use the function to reset
+           ;; the variable when called.
            (completing-read-function
             (lambda (&rest args)
               (setq completing-read-function crf)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1623,9 +1623,10 @@ PREDICATE, see `read-file-name'."
           (buf (current-buffer)))
       (setq completing-read-function
             (lambda (&rest args)
-              (when (buffer-live-p buf)
-                (with-current-buffer buf
-                  (setq completing-read-function crf)))
+              (if (buffer-live-p buf)
+                  (with-current-buffer buf
+                    (setq completing-read-function crf))
+                (setq completing-read-function crf))
               (apply #'selectrum--completing-read-file-name args)))
       (read-file-name-default
        prompt dir

--- a/selectrum.el
+++ b/selectrum.el
@@ -1609,15 +1609,16 @@ PREDICATE, see `read-file-name'."
                                               default-directory))))
                  (set-syntax-table
                   selectrum--minibuffer-local-filename-syntax)))
-    ;; <https://github.com/raxod502/selectrum/issues/61>. When let
-    ;; binding `completing-read-function' and you invoke another
-    ;; Selectrum command recursively then it inherits that binding,
-    ;; even if the new Selectrum command is not reading file names.
-    ;; This causes an error. Previously we rebound it in the next
-    ;; `selectrum-read' call but this only works if the users default
-    ;; `completing-read-function' is `selectrum-completing-read'. So
-    ;; instead of let binding it we set it temporarily to a function
-    ;; which resets the variable when called.
+    ;; <https://github.com/raxod502/selectrum/issues/61>. Previously
+    ;; `completing-read-function' was let bind. When you invoke
+    ;; another Selectrum command recursively then it inherits that
+    ;; binding, even if the new Selectrum command is not reading file
+    ;; names. This causes an error. We circumvented that by rebinding
+    ;; it in the next `selectrum-read' call but this only works if the
+    ;; users default `completing-read-function' is
+    ;; `selectrum-completing-read'. So instead of let binding it we
+    ;; now set it temporarily to a function which resets the variable
+    ;; when called.
     (let ((crf completing-read-function)
           (buf (current-buffer)))
       (setq completing-read-function

--- a/selectrum.el
+++ b/selectrum.el
@@ -1623,13 +1623,13 @@ PREDICATE, see `read-file-name'."
                       completing-read-function))
           (buf (current-buffer)))
       (setq-local completing-read-function
-            (lambda (&rest args)
-              (when (buffer-live-p buf)
-                (with-current-buffer buf
-                  (if local
-                      (setq-local completing-read-function local)
-                    (kill-local-variable 'completing-read-function))))
-              (apply #'selectrum--completing-read-file-name args)))
+                  (lambda (&rest args)
+                    (when (buffer-live-p buf)
+                      (with-current-buffer buf
+                        (if local
+                            (setq-local completing-read-function local)
+                          (kill-local-variable 'completing-read-function))))
+                    (apply #'selectrum--completing-read-file-name args)))
       (read-file-name-default
        prompt dir
        ;; We don't pass default-candidate here to avoid that


### PR DESCRIPTION
Currently we rebind `completing-read-function` in the next `selectrum-read` call but this is a bit cleaner because the handling can be moved into `selectrum-read-file-name` itself. The binding of `completing-read-function` gets now reset there to the previous value as soon as possible.

No user visible change so no changelog needed.

