### PR TITLE
Don't copy candidates function in selectrum-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ The format is based on [Keep a Changelog].
   merged lines ([#133]).
 
 ### Bugs fixed
+* When passing a named function or compiled lambda as `candidates`
+  argument to `selectrum-read` an error would be thrown, which has
+  been fixed ([#163]).
 * When selecting file name prompts and submitting them the result will
   be the selected prompt. Previously it could be the default file name
   passed to `selectrum-read-file-name` which is the behavior of
@@ -140,6 +143,7 @@ The format is based on [Keep a Changelog].
 [#159]: https://github.com/raxod502/selectrum/issues/159
 [#160]: https://github.com/raxod502/selectrum/pull/160
 [#161]: https://github.com/raxod502/selectrum/pull/161
+[#163]: https://github.com/raxod502/selectrum/pull/163
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1277,7 +1277,8 @@ and `minibuffer-completion-predicate'. They are used for internal
 purposes and compatibility to Emacs completion API. By passing
 these as keyword arguments they will be dynamically bound as per
 semantics of `cl-defun'."
-  (unless may-modify-candidates
+  (unless (or may-modify-candidates
+              (functionp candidates))
     (setq candidates (copy-sequence candidates)))
   (selectrum--save-global-state
     (setq selectrum--read-args (cl-list* prompt candidates args))


### PR DESCRIPTION
The `copy-seqence` doesn't complain when copying uncompiled lambdas but I noticed the bug when I got an error when passing a compiled one. 