### PR TITLE
Update handling of minibuffer message overlays

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -1797,12 +1797,11 @@ not at the end of the candidate list.
 This is an `:around' advice for `minibuffer-message'. FUNC and
 ARGS are standard as in all `:around' advice."
   (if (bound-and-true-p selectrum-active-p)
-      (cl-letf* ((orig-make-overlay (symbol-function #'make-overlay))
-                 ((symbol-function #'make-overlay)
-                  (lambda (_beg _end &rest args)
-                    (apply orig-make-overlay
-                           selectrum--end-of-input-marker
-                           selectrum--end-of-input-marker
+      (cl-letf* ((orig-put-text-property (symbol-function #'put-text-property))
+                 ((symbol-function #'put-text-property)
+                  (lambda (beg end key val &rest args)
+                    (apply orig-put-text-property
+                           beg end key (if (eq key 'cursor) 1 val)
                            args))))
         (apply func args))
     (apply func args)))


### PR DESCRIPTION
The cursor would jump forth and back when displaying the message. Overriding `make-overlay` isn't necessary any more because the content is only defined by the input now but instead we need to make sure the cursor stays at the front of the overlay by overriding `put-text-property` when calling `minibuffer-message`. I won't merge this before also adjusting `selectrum--fix-set-minibuffer-message` which I will do after upgrading to Emacs 27 where I can test it.
