### PR TITLE
Fix selectrum-candidate-display-right-margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ The format is based on [Keep a Changelog].
   [#113] and [#118].
 
 ### Enhancements
+* If `selectrum-candidate-display-right-margin` is used the margin is
+  included in the highlighting of the selected candidate so it's
+  easier to see to which candidate the margin belongs to.
 * If the `default-filename` passed to `selectrum-read-file-name` is an
   absolute path it will still be sorted to the top when it is
   contained in the prompting directory ([#160]).


### PR DESCRIPTION
When we switched to use an overlay for candidates display in #133 I forgot to update the code which handles the display of `selectrum-candidate-display-right-margin` so margins aren't currently displayed any more. This was after the last release so there is no changelog entry for this fix. But when fixing this I also used the opportunity to include the margins in the highlighting of the selected candidate because otherwise it's hard to see which candidate a margin string belongs to (which was my initial motivation for opening #83).