### PR TITLE
The minibuffer's hight not resize as the cands after #154, fixup it

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -796,15 +796,16 @@ PRED defaults to `minibuffer-completion-predicate'."
 FIRST is the index of the first displayed candidate. HIGHLIGHTED
 is the index if the highlighted candidate. CANDS are the
 currently displayed candidates."
-  (when-let ((n (1+ selectrum-num-candidates-displayed))
+  (when-let ((n (if selectrum-fix-minibuffer-height
+                    (1+ selectrum-num-candidates-displayed)
+                  (max (window-height)               ; grow only
+                       (1+ (length cands)))))
              (win (active-minibuffer-window)))
     ;; Don't attempt to resize a minibuffer frame.
     (unless (frame-root-window-p win)
       ;; Set min initial height.
-      (when (and selectrum-fix-minibuffer-height
-                 selectrum--init-p)
-        (with-selected-window win
-          (setf (window-height) n)))
+      (with-selected-window win
+        (setf (window-height) n))
       ;; Adjust if needed.
       (when (or selectrum--init-p
                 (and selectrum--current-candidate-index


### PR DESCRIPTION
Since I updated to the latest selectrum (#154), the height of the minibuffer
is sometimes incorrectly displayed. For example, if the INPUT is 'abc',
there will be two candidates. If you delete 'abc' and replace it with 'xyz'
which should be 20 more candidates, but the height of the minibuffer is
still only 3.

The following code seems to solve the problem.