### PR TITLE
Improve minibuffer-message

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -1883,6 +1883,7 @@ the candidate list and the cursor should stay at the front.
 This is an `:around' advice for `minibuffer-message'. FUNC and
 ARGS are standard as in all `:around' advice."
   (if (bound-and-true-p selectrum-active-p)
+      ;; Delay execution so candidates get displayed first.
       (run-at-time
        0 nil
        (lambda ()
@@ -1890,6 +1891,8 @@ ARGS are standard as in all `:around' advice."
                      (symbol-function #'put-text-property))
                     ((symbol-function #'put-text-property)
                      (lambda (beg end key val &rest args)
+                       ;; Set cursor property like
+                       ;; `set-minibuffer-message' in Emacs 27.
                        (apply orig-put-text-property
                               beg end key (if (eq key 'cursor) 1 val)
                               args)))
@@ -1898,6 +1901,8 @@ ARGS are standard as in all `:around' advice."
                     ((symbol-function #'make-overlay)
                      (lambda (&rest args)
                        (let ((ov (apply orig-make-overlay args)))
+                         ;; Set overlay priority like
+                         ;; `set-minibuffer-message' in Emacs 27.
                          (overlay-put ov 'priority 1100)
                          ov))))
            (apply func args))))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1871,13 +1871,14 @@ shadows correctly."
 (defun selectrum--fix-minibuffer-message (func &rest args)
   "Ensure the cursor stays at the front of the minibuffer message.
 This advice adjusts where the cursor gets placed for the overlay
-of `minibuffer-message'.
+of `minibuffer-message' and ensures the overlay gets displayed at
+the right place without blocking the display of candidates.
 
 To test that this advice is working correctly, type \\[find-file]
-twice in a row. The overlay indicating that recursive minibuffers
-are not allowed should appear right after the user input area,
-not at the end of the candidate list and the cursor should stay
-at the front.
+twice in a row with `enable-recursive-minibuffers' set to nil.
+The overlay indicating that recursive minibuffers are not allowed
+should appear right after the user input area, not at the end of
+the candidate list and the cursor should stay at the front.
 
 This is an `:around' advice for `minibuffer-message'. FUNC and
 ARGS are standard as in all `:around' advice."


### PR DESCRIPTION
After switching to Emacs 27 I noticed that `minibuffer-message` still has some problems. When you quit from a recursive session you see the message and the previous prompt but the display of candidates is delayed until after that. By delaying the execution of `minibuffer-message` one can jump straight to the previous session without delayed display of candidates. I additionally had to change the overlay priority like they do in `set-mininbuffer-message` so the overlay would display at the right place with the candidates overlay already present.

This problem wasn't present before we switched to using an overlay for candidates display so there is no changelog.