### PR TITLE
Add ability to use input history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ The format is based on [Keep a Changelog].
   configuring bindings ([#186]). This better meets users'
   expectations, and allows other packages (e.g., General) to better
   work with Selectrum's keybindings ([#71]).
-* The history now uses previous inputs by default. This can be changed
-  by configuring `selectrum-history-use-input`. You can toggle the
-  history format dynamically using `selectrum-toggle-history-format`.
 
 ### Features
+* The history now uses previous inputs by default. This can be changed
+  by configuring `selectrum-history-use-input`. You can also toggle
+  the history format dynamically using
+  `selectrum-toggle-history-format`.
 * The user option `selectrum-completing-read-multiple-show-help` can
   be used to control display of additional usage information in the
   prompt in a `completing-read-multiple` session ([#130], [#132]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The format is based on [Keep a Changelog].
   configuring bindings ([#186]). This better meets users'
   expectations, and allows other packages (e.g., General) to better
   work with Selectrum's keybindings ([#71]).
+* The history now uses previous inputs by default. This can be changed
+  by configuring `selectrum-history-use-input`. You can toggle the
+  history format dynamically using `selectrum-toggle-history-format`.
 
 ### Features
 * The user option `selectrum-completing-read-multiple-show-help` can

--- a/README.md
+++ b/README.md
@@ -176,8 +176,10 @@ editing bindings. So, for example:
   Alternatively, like in default completion, you can type `~/` after a
   `/` to ignore the preceding input and move to the home directory.
 * Minibuffer history navigation works as usual with `M-p` and `M-n`.
-  `M-r` will invoke an improved version of history search with
-  completion.
+  You can decide using previous inputs or previous selected candidates
+  as history items using `selectrum-history-use-input`. The format can
+  also be toggled dynamically using `M-j`. `M-r` will invoke an
+  improved version of history search with completion.
 
 ### Sorting and filtering
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -1351,8 +1351,8 @@ list). A null or non-positive ARG inserts the candidate corresponding to
 Toggles between input history and previously selected candidate
 history. See `selectrum-history-use-input'."
   (interactive)
-  (setq selectrum-history-use-input
-        (not selectrum-history-use-input))
+  (setq-local selectrum-history-use-input
+              (not selectrum-history-use-input))
   (minibuffer-message "Toggled to %s history"
                       (if selectrum-history-use-input
                           "input"
@@ -1487,8 +1487,7 @@ Otherwise, just eval BODY."
               selectrum--read-args
               selectrum--count-overlay
               selectrum--repeat
-              selectrum-active-p
-              selectrum-history-use-input)))
+              selectrum-active-p)))
      ;; https://github.com/raxod502/selectrum/issues/39#issuecomment-618350477
      (selectrum--let-maybe
        selectrum-active-p

--- a/selectrum.el
+++ b/selectrum.el
@@ -619,7 +619,7 @@ PRED defaults to `minibuffer-completion-predicate'."
       (selectrum--minibuffer-post-command-hook))))
 
 (defun selectrum--add-current-history ()
-  "Add item to history list for the completing.
+  "Add candidate to history.
 
 Item will be the selected candidate when `selectrum-history-style'
 is 'candidate, or be the current input string when `selectrum-history-style'

--- a/selectrum.el
+++ b/selectrum.el
@@ -1271,7 +1271,8 @@ plus CANDIDATE."
               (item (propertize
                      (substring-no-properties result)
                      'selectrum--input-history
-                     (if (string-empty-p input) result input))))
+                     (substring-no-properties
+                      (if (string-empty-p input) result input)))))
         (selectrum--add-to-history item))
       ;; History was already handled above don't additionally add
       ;; minibuffer contents on exit.

--- a/selectrum.el
+++ b/selectrum.el
@@ -692,9 +692,9 @@ PRED defaults to `minibuffer-completion-predicate'."
 
 (defun selectrum--minibuffer-history-value ()
   "Get minibuffer history for current session.
-Can be a list or history items or t if history should be ignored.
+Can be a list of history items or t if history should be ignored.
 Depending on `selectrum-history-use-input' the history list will
-contain the input or the selected items."
+contain the input or the previously selected candidates."
   (or (eq t minibuffer-history-variable)
       (let* ((value (if (fboundp 'minibuffer-history-value)
                         (minibuffer-history-value)
@@ -712,7 +712,7 @@ contain the input or the selected items."
           selectrum--input-history))))
 
 (defun selectrum--get-current-history-var ()
-  "Get symbol for current `minibuffer-history-variable'."
+  "Get symbol of current `minibuffer-history-variable'."
   (or (eq t minibuffer-history-variable)
       (if (not selectrum-history-use-input)
           minibuffer-history-variable
@@ -1273,7 +1273,7 @@ plus CANDIDATE."
                      'selectrum--input-history
                      (if (string-empty-p input) result input))))
         (selectrum--add-to-history item))
-      ;; Don't auto add history item for this session.
+      ;; Don't add history we handled it above.
       (setq-local history-add-new-input nil))
     (erase-buffer)
     (insert (if (string-empty-p result)
@@ -1347,8 +1347,8 @@ list). A null or non-positive ARG inserts the candidate corresponding to
 
 (defun selectrum-toggle-history-format ()
   "Toggle current history format.
-Toggles between selection and input history. See
-also `selectrum-history-use-input'."
+Toggles between input history and previously selected candidate
+history. See `selectrum-history-use-input'."
   (interactive)
   (setq selectrum-history-use-input
         (not selectrum-history-use-input))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1023,7 +1023,7 @@ used as the history-variable."
   (add-hook
    'minibuffer-exit-hook #'selectrum--minibuffer-exit-hook nil 'local)
   (setq-local selectrum--init-p t)
-  (setq selectrum--current-history history)
+  (setq-local selectrum--current-history history)
   (unless selectrum--candidates-overlay
     (setq selectrum--candidates-overlay
           (make-overlay (point) (point) nil 'front-advance 'rear-advance)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -706,7 +706,7 @@ contain the input or the previously selected candidates."
             (setq-local selectrum--input-history-cache
                         (mapcar (lambda (item)
                                   (or (get-text-property
-                                       0 'selectrum--input-history-cache item)
+                                       0 'selectrum--input-history item)
                                       item))
                                 value)))
           selectrum--input-history-cache))))
@@ -1269,9 +1269,8 @@ plus CANDIDATE."
                       selectrum--start-of-input-marker
                       selectrum--end-of-input-marker))
               (item (propertize
-                     result
-                     'selectrum--input-history-cache
                      (substring-no-properties result)
+                     'selectrum--input-history
                      (if (string-empty-p input) result input))))
         (selectrum--add-to-history item))
       ;; History was already handled above don't additionally add

--- a/selectrum.el
+++ b/selectrum.el
@@ -1411,6 +1411,7 @@ If Selectrum isn't active, don't exit after submission."
                   (enable-recursive-minibuffers t))
              (minibuffer-with-setup-hook
                  (lambda ()
+                   (use-local-map (copy-keymap (current-local-map)))
                    (define-key (current-local-map)
                      [remap selectrum-insert-current-candidate]
                      'selectrum-insert-input-history)

--- a/selectrum.el
+++ b/selectrum.el
@@ -717,8 +717,8 @@ needed."
     (if (fboundp 'minibuffer-history-value)
         ;; Respect possibly local history variable.
         (with-current-buffer (window-buffer (minibuffer-selected-window))
-          (add-to-history minibuffer-history-variable item))
-      (add-to-history minibuffer-history-variable item))))
+          (add-to-history minibuffer-history-variable item nil 'keep-all))
+      (add-to-history minibuffer-history-variable item nil 'keep-all))))
 
 ;;;; Hook functions
 
@@ -1255,12 +1255,13 @@ plus CANDIDATE."
                         (selectrum--get-full candidate))))
          (inhibit-read-only t))
     (when history-add-new-input
-      (let ((item (propertize
-                   result
-                   'selectrum--input-history
-                   (buffer-substring-no-properties
-                    selectrum--start-of-input-marker
-                    selectrum--end-of-input-marker))))
+      (let*  ((input (buffer-substring-no-properties
+                      selectrum--start-of-input-marker
+                      selectrum--end-of-input-marker))
+              (item (propertize
+                     result
+                     'selectrum--input-history
+                     (if (string-empty-p input) result input))))
         (selectrum--add-to-history item))
       ;; Don't auto add history item for this session.
       (setq-local history-add-new-input nil))

--- a/selectrum.el
+++ b/selectrum.el
@@ -187,8 +187,11 @@ strings."
     ([remap next-line]                        . selectrum-next-candidate)
     ([remap previous-line-or-history-element] . selectrum-previous-candidate)
     ([remap next-line-or-history-element]     . selectrum-next-candidate)
-    ([remap previous-history-element]         . selectrum-previous-history-element)
+    ([remap previous-history-element]
+     . selectrum-previous-history-element)
     ([remap next-history-element]             . selectrum-next-history-element)
+    ("M-j"
+     . selectrum-toggle-history-format)
     ([remap exit-minibuffer]
      . selectrum-select-current-candidate)
     ([remap scroll-down-command]              . selectrum-previous-page)
@@ -695,7 +698,21 @@ PRED defaults to `minibuffer-completion-predicate'."
           selectrum--input-history)
     'selectrum--input-history-variable))
 
+(defun selectrum-toggle-history-format ()
+  "Toggle current history format.
+Toggles the value of `selectrum-history-use-input' and updates
+the minibuffer accordingly."
   (interactive)
+  (setq selectrum-history-use-input
+        (not selectrum-history-use-input))
+  (let ((n (1- minibuffer-history-position)))
+    (when (>= n 0)
+      (delete-minibuffer-contents)
+      (insert
+       (nth n (symbol-value
+               (selectrum--get-current-history-var)))))))
+
+
 (defun selectrum-previous-history-element (n)
   "Forward to `previous-history-element'.
 With argument N, it uses the Nth previous element."

--- a/selectrum.el
+++ b/selectrum.el
@@ -1363,7 +1363,7 @@ semantics of `cl-defun'."
              candidates
              :default-candidate default-candidate
              :initial-input initial-input
-             :history history))
+             :history (or history 'minibuffer-history)))
         (let* ((minibuffer-allow-text-properties t)
                (resize-mini-windows 'grow-only)
                (max-mini-window-height

--- a/selectrum.el
+++ b/selectrum.el
@@ -1417,9 +1417,10 @@ If Selectrum isn't active, don't exit after submission."
                (catch 'insert-action
                  (completing-read
                   (format
-                   "History (press %s to insert input history): "
+                   "History (press %s to insert %s): "
                    (substitute-command-keys
-                    "\\[selectrum-insert-current-candidate]"))
+                    "\\[selectrum-insert-current-candidate]")
+                   (propertize "input history" 'face 'italic))
                   (lambda (string pred action)
                     (if (eq action 'metadata)
                         '(metadata

--- a/selectrum.el
+++ b/selectrum.el
@@ -1387,8 +1387,11 @@ If Selectrum isn't active, don't exit after submission."
                                 ;; Allow to match against both.
                                 (propertize
                                  (concat item
-                                         (propertize " -- " 'face 'bold)
-                                         input)
+                                         " ["
+                                         (propertize
+                                          input
+                                          'face 'italic)
+                                         "]")
                                  'selectrum-candidate-full item
                                  'input input)))
                             history input/history))

--- a/selectrum.el
+++ b/selectrum.el
@@ -720,39 +720,6 @@ needed."
           (add-to-history minibuffer-history-variable item))
       (add-to-history minibuffer-history-variable item))))
 
-(defun selectrum-toggle-history-format ()
-  "Toggle current history format.
-Toggles the value of `selectrum-history-use-input' and updates
-the minibuffer accordingly."
-  (interactive)
-  (setq selectrum-history-use-input
-        (not selectrum-history-use-input))
-  (minibuffer-message "Toggled to %s history"
-                      (if selectrum-history-use-input
-                          "input"
-                        "selection"))
-  (when (> minibuffer-history-position 0)
-    (delete-minibuffer-contents)
-    (insert
-     (nth (1- minibuffer-history-position)
-          (selectrum--minibuffer-history-value)))))
-
-(defun selectrum-previous-history-element (n)
-  "Forward to `previous-history-element'.
-With argument N, it uses the Nth previous element."
-  (interactive "p")
-  (let ((minibuffer-history-variable
-         (selectrum--get-current-history-var)))
-    (previous-history-element n)))
-
-(defun selectrum-next-history-element (n)
-  "Forward to `next-history-element'.
-With argument N, it uses the Nth following element."
-  (interactive "p")
-  (let ((minibuffer-history-variable
-         (selectrum--get-current-history-var)))
-    (next-history-element n)))
-
 ;;;; Hook functions
 
 (defun selectrum--count-info ()
@@ -1366,6 +1333,39 @@ list). A null or non-positive ARG inserts the candidate corresponding to
        #'run-hook-with-args
        'selectrum-candidate-inserted-hook
        candidate selectrum--read-args))))
+
+(defun selectrum-toggle-history-format ()
+  "Toggle current history format.
+Toggles the value of `selectrum-history-use-input' and updates
+the minibuffer accordingly."
+  (interactive)
+  (setq selectrum-history-use-input
+        (not selectrum-history-use-input))
+  (minibuffer-message "Toggled to %s history"
+                      (if selectrum-history-use-input
+                          "input"
+                        "selection"))
+  (when (> minibuffer-history-position 0)
+    (delete-minibuffer-contents)
+    (insert
+     (nth (1- minibuffer-history-position)
+          (selectrum--minibuffer-history-value)))))
+
+(defun selectrum-previous-history-element (n)
+  "Forward to `previous-history-element'.
+With argument N, it uses the Nth previous element."
+  (interactive "p")
+  (let ((minibuffer-history-variable
+         (selectrum--get-current-history-var)))
+    (previous-history-element n)))
+
+(defun selectrum-next-history-element (n)
+  "Forward to `next-history-element'.
+With argument N, it uses the Nth following element."
+  (interactive "p")
+  (let ((minibuffer-history-variable
+         (selectrum--get-current-history-var)))
+    (next-history-element n)))
 
 (defun selectrum-select-from-history ()
   "Select a candidate from the minibuffer history.

--- a/selectrum.el
+++ b/selectrum.el
@@ -1273,7 +1273,8 @@ plus CANDIDATE."
                      'selectrum--input-history
                      (if (string-empty-p input) result input))))
         (selectrum--add-to-history item))
-      ;; Don't add history we handled it above.
+      ;; History was already handled above don't additionally add
+      ;; minibuffer contents on exit.
       (setq-local history-add-new-input nil))
     (erase-buffer)
     (insert (if (string-empty-p result)

--- a/selectrum.el
+++ b/selectrum.el
@@ -247,8 +247,8 @@ Possible values are:
 (defcustom selectrum-history-use-input t
   "Whether to use input for history.
 If non-nil selectrum will provide input history, otherwise the
-history items will contain the selected candidates. You can
-toggle the history format dynamically using
+history will contain the selected candidates. You can toggle the
+history format dynamically using
 `selectrum-toggle-history-format'."
   :type 'boolean)
 
@@ -674,14 +674,15 @@ PRED defaults to `minibuffer-completion-predicate'."
       (selectrum--minibuffer-post-command-hook))))
 
 (defvar selectrum--input-history-variable nil
-  "Stores the history input as `minibuffer-history-variable'.")
+  "Stores the input history as `minibuffer-history-variable'.")
 
 (defvar-local selectrum--input-history nil
   "Input history for current session.")
 
 (defun selectrum--minibuffer-history-value ()
-  "Get current value of `minibuffer-history-variable'.
-Depending on `selectrum-history-use-input' the history will
+  "Get minibuffer history for current session.
+Can be a list or history items or t if history should be ignored.
+Depending on `selectrum-history-use-input' the history list will
 contain the input or the selected items."
   (or (eq t minibuffer-history-variable)
       (let* ((value (if (fboundp 'minibuffer-history-value)
@@ -700,9 +701,7 @@ contain the input or the selected items."
           selectrum--input-history))))
 
 (defun selectrum--get-current-history-var ()
-  "Get symbol to be used as `minibuffer-history-variable'.
-This will initialize `selectrum--input-history-variable' if
-needed."
+  "Get symbol for current `minibuffer-history-variable'."
   (or (eq t minibuffer-history-variable)
       (if (not selectrum-history-use-input)
           minibuffer-history-variable
@@ -712,7 +711,7 @@ needed."
         'selectrum--input-history-variable)))
 
 (defun selectrum--add-to-history (item)
-  "Add ITEM to `minibuffer-history-variable'."
+  "Add ITEM to current minibuffer history."
   (unless (eq t minibuffer-history-variable)
     (if (fboundp 'minibuffer-history-value)
         ;; Respect possibly local history variable.
@@ -1337,8 +1336,8 @@ list). A null or non-positive ARG inserts the candidate corresponding to
 
 (defun selectrum-toggle-history-format ()
   "Toggle current history format.
-Toggles the value of `selectrum-history-use-input' and updates
-the minibuffer accordingly."
+Toggles between selection and input history. See
+also `selectrum-history-use-input'."
   (interactive)
   (setq selectrum-history-use-input
         (not selectrum-history-use-input))
@@ -1426,7 +1425,7 @@ If Selectrum isn't active, don't exit after submission."
 
 (defun selectrum-insert-input-history ()
   "Insert input history item.
-To be used from `selectrum-select-from-history'"
+Only to be used from `selectrum-select-from-history'"
   (interactive)
   (throw 'insert-action
          (propertize (get-text-property

--- a/selectrum.el
+++ b/selectrum.el
@@ -1384,7 +1384,7 @@ If Selectrum isn't active, don't exit after submission."
                               (if (or (equal item input)
                                       (string-empty-p input))
                                   (propertize item 'input item)
-                                ;; Allow to match agains both.
+                                ;; Allow to match against both.
                                 (propertize
                                  (concat item
                                          (propertize " -- " 'face 'bold)

--- a/selectrum.el
+++ b/selectrum.el
@@ -687,8 +687,8 @@ PRED defaults to `minibuffer-completion-predicate'."
 (defvar selectrum--input-history-variable nil
   "Stores the input history as `minibuffer-history-variable'.")
 
-(defvar-local selectrum--input-history nil
-  "Input history for current session.")
+(defvar-local selectrum--input-history-cache nil
+  "Cache input history for current session.")
 
 (defun selectrum--minibuffer-history-value ()
   "Get minibuffer history for current session.
@@ -702,14 +702,14 @@ contain the input or the previously selected candidates."
         (if (not selectrum-history-use-input)
             value
           ;; Init session history one time.
-          (unless selectrum--input-history
-            (setq-local selectrum--input-history
+          (unless selectrum--input-history-cache
+            (setq-local selectrum--input-history-cache
                         (mapcar (lambda (item)
                                   (or (get-text-property
-                                       0 'selectrum--input-history item)
+                                       0 'selectrum--input-history-cache item)
                                       item))
                                 value)))
-          selectrum--input-history))))
+          selectrum--input-history-cache))))
 
 (defun selectrum--get-current-history-var ()
   "Get symbol of current `minibuffer-history-variable'."
@@ -1270,7 +1270,7 @@ plus CANDIDATE."
                       selectrum--end-of-input-marker))
               (item (propertize
                      result
-                     'selectrum--input-history
+                     'selectrum--input-history-cache
                      (if (string-empty-p input) result input))))
         (selectrum--add-to-history item))
       ;; History was already handled above don't additionally add

--- a/selectrum.el
+++ b/selectrum.el
@@ -510,7 +510,7 @@ This is non-nil during the first call of
 `selectrum--minibuffer-post-command-hook'.")
 
 (defvar-local selectrum--current-history nil
-  "Saved the history-var of completing.")
+  "The value of `minibuffer-history-variable' for the current session.")
 
 (defvar selectrum--total-num-candidates nil
   "Saved number of candidates, used for `selectrum-show-indices'.")

--- a/selectrum.el
+++ b/selectrum.el
@@ -1472,7 +1472,8 @@ Otherwise, just eval BODY."
               selectrum--read-args
               selectrum--count-overlay
               selectrum--repeat
-              selectrum-active-p)))
+              selectrum-active-p
+              selectrum-history-use-input)))
      ;; https://github.com/raxod502/selectrum/issues/39#issuecomment-618350477
      (selectrum--let-maybe
        selectrum-active-p

--- a/selectrum.el
+++ b/selectrum.el
@@ -1402,7 +1402,10 @@ If Selectrum isn't active, don't exit after submission."
                    (setq-local selectrum-candidate-selected-hook nil))
                (catch 'insert-action
                  (completing-read
-                  "History (press TAB to insert input history): "
+                  (format
+                   "History (press %s to insert input history): "
+                   (substitute-command-keys
+                    "\\[selectrum-insert-current-candidate]"))
                   (lambda (string pred action)
                     (if (eq action 'metadata)
                         '(metadata

--- a/selectrum.el
+++ b/selectrum.el
@@ -711,6 +711,15 @@ needed."
               (selectrum--minibuffer-history-value))
         'selectrum--input-history-variable)))
 
+(defun selectrum--add-to-history (item)
+  "Add ITEM to `minibuffer-history-variable'."
+  (unless (eq t minibuffer-history-variable)
+    (if (fboundp 'minibuffer-history-value)
+        ;; Respect possibly local history variable.
+        (with-current-buffer (window-buffer (minibuffer-selected-window))
+          (add-to-history minibuffer-history-variable item))
+      (add-to-history minibuffer-history-variable item))))
+
 (defun selectrum-toggle-history-format ()
   "Toggle current history format.
 Toggles the value of `selectrum-history-use-input' and updates
@@ -1285,10 +1294,7 @@ plus CANDIDATE."
                    (buffer-substring-no-properties
                     selectrum--start-of-input-marker
                     selectrum--end-of-input-marker))))
-        (when (> (length item) 0)
-          ;; Respect possibly local history variable.
-          (with-current-buffer (window-buffer (minibuffer-selected-window))
-            (add-to-history minibuffer-history-variable item))))
+        (selectrum--add-to-history item))
       ;; Don't auto add history item for this session.
       (setq-local history-add-new-input nil))
     (erase-buffer)
@@ -1355,8 +1361,7 @@ list). A null or non-positive ARG inserts the candidate corresponding to
                            selectrum--refined-candidates))
            (full (selectrum--get-full candidate)))
       (insert full)
-      (unless (eq t minibuffer-history-variable)
-        (add-to-history minibuffer-history-variable full))
+      (selectrum--add-to-history full)
       (apply
        #'run-hook-with-args
        'selectrum-candidate-inserted-hook

--- a/selectrum.el
+++ b/selectrum.el
@@ -1407,7 +1407,6 @@ If Selectrum isn't active, don't exit after submission."
                                  'selectrum-candidate-full item
                                  'input input)))
                             history input/history))
-                  (sactive selectrum-active-p)
                   (enable-recursive-minibuffers t))
              (minibuffer-with-setup-hook
                  (lambda ()
@@ -1419,7 +1418,7 @@ If Selectrum isn't active, don't exit after submission."
                    (setq-local selectrum-candidate-selected-hook nil))
                (catch 'insert-action
                  (completing-read
-                  (if (not sactive) "History: "
+                  (if (not selectrum-active-p) "History: "
                     (format
                      "History (press %s to insert %s): "
                      (substitute-command-keys

--- a/selectrum.el
+++ b/selectrum.el
@@ -1407,6 +1407,7 @@ If Selectrum isn't active, don't exit after submission."
                                  'selectrum-candidate-full item
                                  'input input)))
                             history input/history))
+                  (sactive selectrum-active-p)
                   (enable-recursive-minibuffers t))
              (minibuffer-with-setup-hook
                  (lambda ()
@@ -1417,11 +1418,12 @@ If Selectrum isn't active, don't exit after submission."
                    (setq-local selectrum-candidate-selected-hook nil))
                (catch 'insert-action
                  (completing-read
-                  (format
-                   "History (press %s to insert %s): "
-                   (substitute-command-keys
-                    "\\[selectrum-insert-current-candidate]")
-                   (propertize "input history" 'face 'italic))
+                  (if (not sactive) "History: "
+                    (format
+                     "History (press %s to insert %s): "
+                     (substitute-command-keys
+                      "\\[selectrum-insert-current-candidate]")
+                     (propertize "input history" 'face 'italic)))
                   (lambda (string pred action)
                     (if (eq action 'metadata)
                         '(metadata

--- a/selectrum.el
+++ b/selectrum.el
@@ -247,8 +247,8 @@ Possible values are:
 (defcustom selectrum-history-use-input t
   "Whether to use input for history.
 If non-nil selectrum will provide input history, otherwise the
-history will contain the selected candidates. You can toggle the
-history format dynamically using
+history will contain the previously selected candidates. You can
+toggle the history format dynamically using
 `selectrum-toggle-history-format'."
   :type 'boolean)
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -633,7 +633,7 @@ The default behavior is 'candidate."
                       selectrum--start-of-input-marker
                       selectrum--end-of-input-marker)))))
     (when (> (length item) 0)
-      (add-to-history (or selectrum--current-history 'minibuffer-history)
+      (add-to-history selectrum--current-history
                       item))))
 
 ;;;; Hook functions

--- a/selectrum.el
+++ b/selectrum.el
@@ -1271,6 +1271,7 @@ plus CANDIDATE."
               (item (propertize
                      result
                      'selectrum--input-history-cache
+                     (substring-no-properties result)
                      (if (string-empty-p input) result input))))
         (selectrum--add-to-history item))
       ;; History was already handled above don't additionally add

--- a/selectrum.el
+++ b/selectrum.el
@@ -621,11 +621,7 @@ PRED defaults to `minibuffer-completion-predicate'."
 (defun selectrum--add-current-history ()
   "Add candidate to history.
 
-Item will be the selected candidate when `selectrum-history-style'
-is 'candidate, or be the current input string when `selectrum-history-style'
-is 'input.
-
-The default behavior is 'candidate."
+What gets added is determined by `selectrum-history-style'."
   (let ((item (cond ((eq selectrum-history-style 'candidate)
                      (selectrum-get-current-candidate))
                     ((eq selectrum-history-style 'input)
@@ -1144,6 +1140,9 @@ plus CANDIDATE."
     (insert (if (string-empty-p result)
                 (or selectrum--default-candidate result)
               result))
+    (when history-add-new-input
+      (selectrum--add-current-history))
+    (setq-local history-add-new-input nil)
     (exit-minibuffer)))
 
 (defun selectrum-select-current-candidate (&optional arg)
@@ -1159,7 +1158,6 @@ Zero means to select the current user input."
                    (min (1- (prefix-numeric-value arg))
                         (1- (length selectrum--refined-candidates)))
                  selectrum--current-candidate-index)))
-    (selectrum--add-current-history)
     (when (or (not selectrum--match-required-p)
               (and index (>= index 0))
               (and minibuffer-completing-file-name
@@ -1175,7 +1173,6 @@ This differs from `selectrum-select-current-candidate' in that it
 ignores the currently selected candidate, if one exists."
   (interactive)
   (unless selectrum--match-required-p
-    (selectrum--add-current-history)
     (selectrum--exit-with (buffer-substring-no-properties
                            selectrum--start-of-input-marker
                            selectrum--end-of-input-marker))))
@@ -1371,7 +1368,6 @@ semantics of `cl-defun'."
                (prompt (selectrum--remove-default-from-prompt prompt))
                ;; <https://github.com/raxod502/selectrum/issues/99>
                (icomplete-mode nil)
-               (history-add-new-input nil)
                (selectrum-active-p t))
           (read-from-minibuffer
            prompt nil keymap nil

--- a/selectrum.el
+++ b/selectrum.el
@@ -1344,7 +1344,7 @@ also `selectrum-history-use-input'."
   (minibuffer-message "Toggled to %s history"
                       (if selectrum-history-use-input
                           "input"
-                        "selection"))
+                        "candidate"))
   (when (> minibuffer-history-position 0)
     (delete-minibuffer-contents)
     (insert


### PR DESCRIPTION
As discussed in #179 this implements the ability to use input history. The behaviour can be toggled interactively by `selectrum-toggle-history-format` (I have used `M-j`, there might be a better one). I also had to think about how `selectrum-select-from-history` should change. For now I experimented with showing both and let the user match against both: The selected candidate and the input history. You can insert the input history item using TAB (new) or submit the history item with RET (as before).

When implementing this I also noticed that setting `selectrum-should-sort-p` buffer locally in setup hook doesn't work in this case. Apparently the buffer local value only takes effect after all minibuffer setup hooks ran.