### PR TITLE
Normalize path prior to checking if file exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ The format is based on [Keep a Changelog].
   `selectrum-select-from-history` and other commands which ignore
   history by setting `minibuffer-history-variable` to `t`. Previously
   an error would be thrown ([#152]).
+* When completing filenames and a match is required, non-normalized
+  paths (e.g., `~/Documents//etc/hosts`) are accepted ([#190]).
 
 [#67]: https://github.com/raxod502/selectrum/issues/67
 [#71]: https://github.com/raxod502/selectrum/issues/71
@@ -165,6 +167,7 @@ The format is based on [Keep a Changelog].
 [#163]: https://github.com/raxod502/selectrum/pull/163
 [#166]: https://github.com/raxod502/selectrum/pull/166
 [#186]: https://github.com/raxod502/selectrum/pull/186
+[#190]: https://github.com/raxod502/selectrum/pull/190
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1130,7 +1130,8 @@ into the user input area to start with."
           (max (if (and selectrum--match-required-p
                         (cond (minibuffer-completing-file-name
                                (not (file-exists-p
-                                     (minibuffer-contents))))
+                                     (substitute-in-file-name
+                                      (minibuffer-contents)))))
                               (t
                                (not (string-empty-p
                                      (minibuffer-contents))))))
@@ -1229,7 +1230,9 @@ Zero means to select the current user input."
     (when (or (not selectrum--match-required-p)
               (and index (>= index 0))
               (and minibuffer-completing-file-name
-                   (file-exists-p (minibuffer-contents)))
+                   (file-exists-p
+                    (substitute-in-file-name
+                     (minibuffer-contents))))
               (string-empty-p
                (minibuffer-contents)))
       (selectrum--exit-with


### PR DESCRIPTION
We need to use ‘substitute-in-file-name’ prior to checking if the
minibuffer contents point to an existing file because we might have a
string such as “~/Documents//etc/hosts” in the minibuffer for which
‘file-exists-p’ will return nil but *is* in fact an existing file.
