### PR TITLE
Be more lenient when pressing TAB and nothing matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,10 @@ The format is based on [Keep a Changelog].
   an error would be thrown ([#152]).
 * When completing filenames and a match is required, non-normalized
   paths (e.g., `~/Documents//etc/hosts`) are accepted ([#190]).
+* Pressing TAB when nothing matches shows a “No match” message in the
+  minibuffer instead of signaling an error and erasing the minibuffer
+  contents ([#193]).  If ‘completion-fail-discreetly’ is non-nil,
+  nothing is done.
 
 [#67]: https://github.com/raxod502/selectrum/issues/67
 [#71]: https://github.com/raxod502/selectrum/issues/71
@@ -168,6 +172,7 @@ The format is based on [Keep a Changelog].
 [#166]: https://github.com/raxod502/selectrum/pull/166
 [#186]: https://github.com/raxod502/selectrum/pull/186
 [#190]: https://github.com/raxod502/selectrum/pull/190
+[#193]: https://github.com/raxod502/selectrum/pull/193
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1257,15 +1257,15 @@ index (counting from one, clamped to fall within the candidate
 list). A null or non-positive ARG inserts the candidate corresponding to
 `selectrum--current-candidate-index'."
   (interactive "P")
-  (if-let* ((index (if (and arg
-                            selectrum--refined-candidates
-                            (> (prefix-numeric-value arg) 0))
-                       (min (1- (prefix-numeric-value arg))
-                            (1- (length selectrum--refined-candidates)))
-                     selectrum--current-candidate-index))
-            (candidate (nth index
-                            selectrum--refined-candidates))
-            (full (selectrum--get-full candidate)))
+  (if-let ((index (if (and arg
+                           selectrum--refined-candidates
+                           (> (prefix-numeric-value arg) 0))
+                      (min (1- (prefix-numeric-value arg))
+                           (1- (length selectrum--refined-candidates)))
+                    selectrum--current-candidate-index))
+           (candidate (nth index
+                           selectrum--refined-candidates))
+           (full (selectrum--get-full candidate)))
       (progn
         (if (or (not selectrum--crm-p)
                 (not (re-search-backward crm-separator

--- a/selectrum.el
+++ b/selectrum.el
@@ -1257,29 +1257,33 @@ index (counting from one, clamped to fall within the candidate
 list). A null or non-positive ARG inserts the candidate corresponding to
 `selectrum--current-candidate-index'."
   (interactive "P")
-  (when-let ((index (if (and arg
-                             selectrum--refined-candidates
-                             (> (prefix-numeric-value arg) 0))
-                        (min (1- (prefix-numeric-value arg))
-                             (1- (length selectrum--refined-candidates)))
-                      selectrum--current-candidate-index)))
-    (if (or (not selectrum--crm-p)
-            (not (re-search-backward crm-separator
-                                     (minibuffer-prompt-end) t)))
-        (delete-region selectrum--start-of-input-marker
-                       selectrum--end-of-input-marker)
-      (goto-char (match-end 0))
-      (delete-region (point) selectrum--end-of-input-marker))
-    (let* ((candidate (nth index
-                           selectrum--refined-candidates))
-           (full (selectrum--get-full candidate)))
-      (insert full)
-      (unless (eq t minibuffer-history-variable)
-        (add-to-history minibuffer-history-variable full))
-      (apply
-       #'run-hook-with-args
-       'selectrum-candidate-inserted-hook
-       candidate selectrum--read-args))))
+  (if-let* ((index (if (and arg
+                            selectrum--refined-candidates
+                            (> (prefix-numeric-value arg) 0))
+                       (min (1- (prefix-numeric-value arg))
+                            (1- (length selectrum--refined-candidates)))
+                     selectrum--current-candidate-index))
+            (candidate (nth index
+                            selectrum--refined-candidates))
+            (full (selectrum--get-full candidate)))
+      (progn
+        (if (or (not selectrum--crm-p)
+                (not (re-search-backward crm-separator
+                                         (minibuffer-prompt-end) t)))
+            (delete-region selectrum--start-of-input-marker
+                           selectrum--end-of-input-marker)
+          (goto-char (match-end 0))
+          (delete-region (point) selectrum--end-of-input-marker))
+        (insert full)
+        (unless (eq t minibuffer-history-variable)
+          (add-to-history minibuffer-history-variable full))
+        (apply
+         #'run-hook-with-args
+         'selectrum-candidate-inserted-hook
+         candidate selectrum--read-args))
+    (unless completion-fail-discreetly
+      (ding)
+      (minibuffer-message "No match"))))
 
 (defun selectrum-select-from-history ()
   "Select a candidate from the minibuffer history.


### PR DESCRIPTION
Currently, an error occurs when TAB is pressed and no candidate
matches the minibuffer contents.  Moreover, the minibuffer contents
are erased.

This commit makes the behavior more lenient and similar to the default
minibuffer completion -- the bell is rung a “No match” message is
displayed.  Also, ‘completion-fail-discreetly’ is respected so none of
the aforementioned things are done if it is non-nil.
