### PR TITLE
Fix selectrum-count-style type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@ The format is based on [Keep a Changelog].
   minibuffer instead of signaling an error and erasing the minibuffer
   contents ([#193]).  If ‘completion-fail-discreetly’ is non-nil,
   nothing is done.
+* Fix type mismatch when configuring `selectrum-count-style` in
+  customizations.
 
 [#67]: https://github.com/raxod502/selectrum/issues/67
 [#71]: https://github.com/raxod502/selectrum/issues/71

--- a/selectrum.el
+++ b/selectrum.el
@@ -245,9 +245,9 @@ Possible values are:
 - nil: Show nothing."
   :type '(choice
           (const :tag "Disabled" nil)
-          (const :tag "Count matches" 'matches)
+          (const :tag "Count matches" matches)
           (const :tag "Count matches and show current match"
-                 'current/matches)))
+                 current/matches)))
 
 (defcustom selectrum-show-indices nil
   "Non-nil means to number the candidates (starting from 1).


### PR DESCRIPTION
Const symbols don't need to be quoted, otherwise there will be a type mismatch in customization.