### PR TITLE
Add selectrum quickselect keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog].
   work with Selectrum's keybindings ([#71]).
 
 ### Features
+* The user option `selectrum-show-indices` can now be a function that
+  can be used to control the display of the a candidate's index ([#200]).
 * The user option `selectrum-completing-read-multiple-show-help` can
   be used to control display of additional usage information in the
   prompt in a `completing-read-multiple` session ([#130], [#132]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog].
   [#113] and [#118].
 
 ### Enhancements
+* Selectrum now by default shows indices relative to displayed
+  candidates ([#200]).
 * If `selectrum-candidate-display-right-margin` is used the margin is
   included in the highlighting of the selected candidate so it's
   easier to see to which candidate the margin belongs to ([#166]).

--- a/README.md
+++ b/README.md
@@ -281,7 +281,10 @@ matching and case-insensitive matching.
   minibuffer by enabling `selectrum-show-indices`. This may be helpful
   in telling you what prefix argument you should pass to
   `selectrum-select-current-candidate` in order to select a given
-  candidate.
+  candidate. Furthermore, if you want do display a custom index (e.g.
+  letters instead of indices, roman numerals, etc.) you can set the
+  `selectrum-show-indices` to a function that takes in the relative
+  index of a candidate and returns the string you want to display.
 * The `selectrum-completion-in-region` function can display
   annotations if the `completion-in-region-function` backend offers
   them. Customize the face `selectrum-completion-annotation` to change

--- a/selectrum.el
+++ b/selectrum.el
@@ -250,11 +250,13 @@ Possible values are:
                  current/matches)))
 
 (defcustom selectrum-show-indices nil
-  "Non-nil means to number the displayed candidates.
-The candidates are numbered from 1 to `selectrum-num-candidates-displayed'.
-This allows you to select one directly by providing a prefix
-argument to `selectrum-select-current-candidate'."
-  :type 'boolean)
+  "Non-nil means to add indices to the displayed candidates.
+If this is a function, it should take in the row number of the
+displayed candidate (starting from 1) as a parameter and it
+should return the string to be displayed representing the index
+of the candidate. If this is some other non-nil value, it is
+treated as if it were (lambda (i) (format \"%2d \" i))."
+  :type '(choice function boolean))
 
 (defcustom selectrum-completing-read-multiple-show-help t
   "Non-nil means to show help for `selectrum-completing-read-multiple'.
@@ -1038,18 +1040,13 @@ candidate."
                'append displayed-candidate)))
           (insert "\n")
           (when selectrum-show-indices
-            (let* ((num (number-to-string (1+ index)))
-                   (num-digits
-                    (length
-                     (number-to-string
-                      selectrum-num-candidates-displayed))))
+            (let* ((display-fn (if (functionp selectrum-show-indices)
+                                   selectrum-show-indices
+                                 (lambda (i) (format "%2d " i))))
+                   (curr-index (substring-no-properties
+                                (funcall display-fn (1+ index)))))
               (insert
-               (propertize
-                (concat
-                 (make-string (- num-digits (length num)) ? )
-                 num " ")
-                'face
-                'minibuffer-prompt))))
+               (propertize curr-index 'face 'minibuffer-prompt))))
           (insert displayed-candidate)
           (when right-margin
             (insert

--- a/selectrum.el
+++ b/selectrum.el
@@ -250,7 +250,8 @@ Possible values are:
                  current/matches)))
 
 (defcustom selectrum-show-indices nil
-  "Non-nil means to number the candidates (starting from 1).
+  "Non-nil means to number the displayed candidates.
+The candidates are numbered from 1 to `selectrum-num-candidates-displayed'.
 This allows you to select one directly by providing a prefix
 argument to `selectrum-select-current-candidate'."
   :type 'boolean)
@@ -1037,12 +1038,11 @@ candidate."
                'append displayed-candidate)))
           (insert "\n")
           (when selectrum-show-indices
-            (let* ((abs-index (+ index first-index-displayed))
-                   (num (number-to-string (1+ abs-index)))
+            (let* ((num (number-to-string (1+ index)))
                    (num-digits
                     (length
                      (number-to-string
-                      selectrum--total-num-candidates))))
+                      selectrum-num-candidates-displayed))))
               (insert
                (propertize
                 (concat
@@ -1224,8 +1224,10 @@ Give a prefix argument ARG to select the candidate at that index
 Zero means to select the current user input."
   (interactive "P")
   (let ((index (if arg
-                   (min (1- (prefix-numeric-value arg))
-                        (1- (length selectrum--refined-candidates)))
+                   (min
+                    (+ (prefix-numeric-value arg)
+                       selectrum--current-candidate-index)
+                    (1- (length selectrum--refined-candidates)))
                  selectrum--current-candidate-index)))
     (when (or (not selectrum--match-required-p)
               (and index (>= index 0))
@@ -1267,11 +1269,11 @@ index (counting from one, clamped to fall within the candidate
 list). A null or non-positive ARG inserts the candidate corresponding to
 `selectrum--current-candidate-index'."
   (interactive "P")
-  (if-let ((index (if (and arg
-                           selectrum--refined-candidates
-                           (> (prefix-numeric-value arg) 0))
-                      (min (1- (prefix-numeric-value arg))
-                           (1- (length selectrum--refined-candidates)))
+  (if-let ((index (if arg
+                      (min
+                       (+ (prefix-numeric-value arg)
+                          selectrum--current-candidate-index)
+                       (1- (length selectrum--refined-candidates)))
                     selectrum--current-candidate-index))
            (candidate (nth index
                            selectrum--refined-candidates))

--- a/selectrum.el
+++ b/selectrum.el
@@ -812,8 +812,7 @@ PRED defaults to `minibuffer-completion-predicate'."
         (let ((text (selectrum--candidates-display-string
                      displayed-candidates
                      input
-                     highlighted-index
-                     first-index-displayed))
+                     highlighted-index))
               (default nil))
           (if (or (and highlighted-index
                        (< highlighted-index 0))
@@ -961,8 +960,7 @@ The specific details of the formatting are determined by
 
 (defun selectrum--candidates-display-string (candidates
                                              input
-                                             highlighted-index
-                                             first-index-displayed)
+                                             highlighted-index)
   "Get string to display CANDIDATES.
 INPUT is the current user input. CANDIDATES are the candidates
 for display. HIGHLIGHTED-INDEX is the currently selected index


### PR DESCRIPTION
<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->

This purpose of this pull request is to make selectrum display indices only on visible candiates and to provide the user with a way to customize the character used for the indices of candidates.

To do this I created (as suggested by @okamsn in #194 ) an alist called `selectrum-quick-selet-keys` whose keys are indices and whose values are the characters that should be displayed for that index.

The name of the variable `selectrum-show-indices` was no longer well suited to its function, therefore I renamed it to  `selectrum-show-quick-select-keys`.

There are a few open questions however.

One is, should the alist use strings as values instead of characters?

Using characters works file for single letters. However, if the user prefers using numbers and has `selectrum-num-candidates-displayed` greater than 10, then there will be double digits and therefore it might be less of a pain using a string.

Another is, should we get rid of the variable `selectrum-show-quick-select-keys` all-together?

Technically we only need the alist. We can just set it to nil by default.

I'm sure there are more things I haven't thought of. So I expect to have to make many more changes.

Finally, I want to make sure to give credit to @okamsn  and @clemera  who were very responsive and helpful when I created this issue.