### PR TITLE
Fix README's example binding selectrum-repeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ matching and case-insensitive matching.
   example:
 
   ```elisp
-  (global-set-key "C-x C-z" #'selectrum-repeat)
+  (global-set-key (kbd "C-x C-z") #'selectrum-repeat)
   ```
 
 * There is experimental support for running Helm commands via the


### PR DESCRIPTION
Really small fix in the README; I was trying out selectrum this afternoon and got an error dropping the example config in my init: `global-set-key: Key sequence C - x SPC C - z starts with non-prefix key C`

Could also be spelled `(global-set-key "\C-x\C-z" #'selectrum-repeat)` 

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
