### PR TITLE
Don't modify candidates returned by dynamic candidate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,20 @@ The format is based on [Keep a Changelog].
 * Selectrum now by default shows indices relative to displayed
   candidates ([#200]).
 
+### Bugs fixed
+* The candiate list returned from a dynamic candidate function passed
+  to `selectrum-read` is now also prevented to be modified in case its
+  a list of strings. Before the list only wasn't modfied when the
+  function returned the alist format as specfied by `selectrum-read`
+  ([#220]).
+
 [#194]: https://github.com/raxod502/selectrum/issues/194
 [#200]: https://github.com/raxod502/selectrum/pull/200
 [#208]: https://github.com/raxod502/selectrum/pull/208
 [#212]: https://github.com/raxod502/selectrum/issues/212
 [#213]: https://github.com/raxod502/selectrum/pull/213
 [#215]: https://github.com/raxod502/selectrum/pull/215
+[#220]: https://github.com/raxod502/selectrum/pull/220
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -730,16 +730,16 @@ PRED defaults to `minibuffer-completion-predicate'."
                                          (funcall
                                           selectrum--preprocessed-candidates
                                           input)))
-                                    (if (stringp (car result))
-                                        result
-                                      (setq input (or (alist-get 'input result)
-                                                      input))
-                                      (setq selectrum--visual-input input)
-                                      ;; Avoid modifying the returned
-                                      ;; candidates to let the function
-                                      ;; reuse them.
-                                      (copy-sequence
-                                       (alist-get 'candidates result)))) )
+                                    ;; Avoid modifying the returned
+                                    ;; candidates to let the function
+                                    ;; reuse them.
+                                    (copy-sequence
+                                     (if (stringp (car result))
+                                         result
+                                       (setq input (or (alist-get 'input result)
+                                                       input))
+                                       (setq selectrum--visual-input input)
+                                       (alist-get 'candidates result)))))
                        selectrum--preprocessed-candidates)))
           (setq selectrum--total-num-candidates (length cands))
           (setq selectrum--refined-candidates

--- a/selectrum.el
+++ b/selectrum.el
@@ -725,21 +725,22 @@ PRED defaults to `minibuffer-completion-predicate'."
         ;; there's no special attention needed.
         (setq selectrum--visual-input nil)
         (let ((cands (if (functionp selectrum--preprocessed-candidates)
-                         (funcall selectrum-preprocess-candidates-function
-                                  (let ((result
-                                         (funcall
-                                          selectrum--preprocessed-candidates
-                                          input)))
-                                    ;; Avoid modifying the returned
-                                    ;; candidates to let the function
-                                    ;; reuse them.
-                                    (copy-sequence
-                                     (if (stringp (car result))
-                                         result
-                                       (setq input (or (alist-get 'input result)
-                                                       input))
-                                       (setq selectrum--visual-input input)
-                                       (alist-get 'candidates result)))))
+                         (funcall
+                          selectrum-preprocess-candidates-function
+                          (let ((result
+                                 (funcall
+                                  selectrum--preprocessed-candidates
+                                  input)))
+                            ;; Avoid modifying the returned
+                            ;; candidates to let the function
+                            ;; reuse them.
+                            (copy-sequence
+                             (if (stringp (car result))
+                                 result
+                               (setq input (or (alist-get 'input result)
+                                               input))
+                               (setq selectrum--visual-input input)
+                               (alist-get 'candidates result)))))
                        selectrum--preprocessed-candidates)))
           (setq selectrum--total-num-candidates (length cands))
           (setq selectrum--refined-candidates


### PR DESCRIPTION
In case the function returned a list of strings we still possibly modified the returned results which can lead to surprises when the functions reuses them.
