### PR TITLE
Refactor selectrum-completion-in-region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ The format is based on [Keep a Changelog].
 [#212]: https://github.com/raxod502/selectrum/issues/212
 [#213]: https://github.com/raxod502/selectrum/pull/213
 [#215]: https://github.com/raxod502/selectrum/pull/215
+[#221]: https://github.com/raxod502/selectrum/pull/221
+
+### Bugs fixed
+* `selectrum-completion-in-region` no longer unsets
+  `selectrum-should-sort-p` for all recursive minibuffer sessions in
+  the case the initial completion table specified its own
+  `display-sort-function` ([#221]).
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog].
   candidate until the margin (the default is nil). See [#208].
 
 ### Enhancements
+* The completion of filenames using `selectrum-completion-in-region`
+  has been improved. The minibuffer gets no longer invoked if there is
+  only a single completion candidate instead the result is inserted in
+  place.
 * The argument passed to `selectrum-select-current-candidate` and
   `selectrum-insert-current-candidate` is now used to choose the nth
   displayed candidate instead of calculating an index based on the
@@ -21,6 +25,12 @@ The format is based on [Keep a Changelog].
 * Selectrum now by default shows indices relative to displayed
   candidates ([#200]).
 
+### Bugs fixed
+* `selectrum-completion-in-region` no longer unsets
+  `selectrum-should-sort-p` for all recursive minibuffer sessions in
+  the case the initial completion table specified its own
+  `display-sort-function` ([#221]).
+
 [#194]: https://github.com/raxod502/selectrum/issues/194
 [#200]: https://github.com/raxod502/selectrum/pull/200
 [#208]: https://github.com/raxod502/selectrum/pull/208
@@ -28,12 +38,6 @@ The format is based on [Keep a Changelog].
 [#213]: https://github.com/raxod502/selectrum/pull/213
 [#215]: https://github.com/raxod502/selectrum/pull/215
 [#221]: https://github.com/raxod502/selectrum/pull/221
-
-### Bugs fixed
-* `selectrum-completion-in-region` no longer unsets
-  `selectrum-should-sort-p` for all recursive minibuffer sessions in
-  the case the initial completion table specified its own
-  `display-sort-function` ([#221]).
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,10 +102,6 @@ The format is based on [Keep a Changelog].
   `completing-read-multiple` ([#197]).
 
 ### Bugs fixed
-* `selectrum-completion-in-region` no longer unsets
-  `selectrum-should-sort-p` for all recursive minibuffer sessions in
-  the case the initial completion table specified its own
-  `display-sort-function` ([#221]).
 * The minibuffer height is now determined by the actual height of
   displayed candidates. Previously the height could be off for
   candidates containing unicode characters or other means which
@@ -205,7 +201,6 @@ The format is based on [Keep a Changelog].
 [#212]: https://github.com/raxod502/selectrum/issues/212
 [#213]: https://github.com/raxod502/selectrum/pull/213
 [#215]: https://github.com/raxod502/selectrum/pull/215
-[#221]: https://github.com/raxod502/selectrum/pull/221
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,6 @@ The format is based on [Keep a Changelog].
 ### Enhancements
 * The user option `selectrum-do-completion-in-region` can be used to
   configure if Selectrum should handle completion in region ([#221]).
-* The completion of filenames by `selectrum-completion-in-region` has
-  been improved. The minibuffer gets no longer invoked if there is
-  only a single completion candidate instead the result is inserted in
-  place ([#221]).
 * The argument passed to `selectrum-select-current-candidate` and
   `selectrum-insert-current-candidate` is now used to choose the nth
   displayed candidate instead of calculating an index based on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ The format is based on [Keep a Changelog].
   `completing-read-multiple` ([#197]).
 
 ### Bugs fixed
+* `selectrum-completion-in-region` no longer unsets
+  `selectrum-should-sort-p` for all recursive minibuffer sessions in
+  the case the initial completion table specified its own
+  `display-sort-function` ([#221]).
 * The minibuffer height is now determined by the actual height of
   displayed candidates. Previously the height could be off for
   candidates containing unicode characters or other means which
@@ -201,6 +205,7 @@ The format is based on [Keep a Changelog].
 [#212]: https://github.com/raxod502/selectrum/issues/212
 [#213]: https://github.com/raxod502/selectrum/pull/213
 [#215]: https://github.com/raxod502/selectrum/pull/215
+[#221]: https://github.com/raxod502/selectrum/pull/221
 
 ## 2.0 (released 2020-07-18)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ The format is based on [Keep a Changelog].
   candidate until the margin (the default is nil). See [#208].
 
 ### Enhancements
-* The completion of filenames using `selectrum-completion-in-region`
-  has been improved. The minibuffer gets no longer invoked if there is
+* The user option `selectrum-do-completion-in-region` can be used to
+  configure if Selectrum should handle completion in region ([#221]).
+* The completion of filenames by `selectrum-completion-in-region` has
+  been improved. The minibuffer gets no longer invoked if there is
   only a single completion candidate instead the result is inserted in
-  place.
+  place ([#221]).
 * The argument passed to `selectrum-select-current-candidate` and
   `selectrum-insert-current-candidate` is now used to choose the nth
   displayed candidate instead of calculating an index based on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ The format is based on [Keep a Changelog].
   candidate until the margin (the default is nil). See [#208].
 
 ### Enhancements
-* The user option `selectrum-do-completion-in-region` can be used to
-  configure if Selectrum should handle completion in region ([#221]).
 * The argument passed to `selectrum-select-current-candidate` and
   `selectrum-insert-current-candidate` is now used to choose the nth
   displayed candidate instead of calculating an index based on the

--- a/selectrum.el
+++ b/selectrum.el
@@ -1614,16 +1614,11 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                (message "No match"))
       (pcase category
         ('file
-         (let ((exact (and (not (cdr cands))
-                           (try-completion input collection predicate))))
-           (if exact
-               (setq result exact
-                     exit-status 'exact)
-             (setq result
-                   (selectrum--completing-read-file-name
-                    "Completion: " collection predicate
-                    nil input)
-                   exit-status 'finished))))
+         (setq result
+               (selectrum--completing-read-file-name
+                "Completion: " collection predicate
+                nil input)
+               exit-status 'finished))
         (_
          (setq result
                (if (not (cdr cands))
@@ -1633,10 +1628,9 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                   (lambda (string pred action)
                     (if (eq action 'metadata)
                         meta
-                      (complete-with-action action cands string pred))))))
-         (setq exit-status
-               (cond ((not (member result cands)) 'sole)
-                     (t 'finished)))))
+                      (complete-with-action action cands string pred)))))
+               exit-status (cond ((not (member result cands)) 'sole)
+                                 (t 'finished)))))
       (delete-region bound end)
       (insert (substring-no-properties result))
       (when exit-func

--- a/selectrum.el
+++ b/selectrum.el
@@ -346,6 +346,13 @@ setting."
 Nil (the default) means to only highlight the displayed text."
   :type 'boolean)
 
+(defcustom selectrum-do-completion-in-region t
+  "Whether to use selectrum for completion in region.
+If this is non-nil `selectrum-mode' will set
+`completion-in-region-function'."
+  :type 'boolean)
+
+
 ;;;; Utility functions
 
 (defun selectrum--clamp (x lower upper)
@@ -1980,10 +1987,11 @@ ARGS are standard as in all `:around' advice."
                 (default-value 'read-file-name-function))
           (setq-default read-file-name-function
                         #'selectrum-read-file-name)
-          (setq selectrum--old-completion-in-region-function
-                (default-value 'completion-in-region-function))
-          (setq-default completion-in-region-function
-                        #'selectrum-completion-in-region)
+          (when selectrum-do-completion-in-region
+            (setq selectrum--old-completion-in-region-function
+                  (default-value 'completion-in-region-function))
+            (setq-default completion-in-region-function
+                          #'selectrum-completion-in-region))
           (advice-add #'completing-read-multiple :override
                       #'selectrum-completing-read-multiple)
           ;; No sharp quote because Dired may not be loaded yet.

--- a/selectrum.el
+++ b/selectrum.el
@@ -1978,7 +1978,7 @@ ARGS are standard as in all `:around' advice."
           (setq selectrum--old-completion-in-region-function
                 (default-value 'completion-in-region-function))
           (setq-default completion-in-region-function
-                          #'selectrum-completion-in-region)
+                        #'selectrum-completion-in-region)
           (advice-add #'completing-read-multiple :override
                       #'selectrum-completing-read-multiple)
           ;; No sharp quote because Dired may not be loaded yet.

--- a/selectrum.el
+++ b/selectrum.el
@@ -346,13 +346,6 @@ setting."
 Nil (the default) means to only highlight the displayed text."
   :type 'boolean)
 
-(defcustom selectrum-do-completion-in-region t
-  "Whether to use selectrum for completion in region.
-If this is non-nil `selectrum-mode' will set
-`completion-in-region-function'."
-  :type 'boolean)
-
-
 ;;;; Utility functions
 
 (defun selectrum--clamp (x lower upper)
@@ -1981,11 +1974,10 @@ ARGS are standard as in all `:around' advice."
                 (default-value 'read-file-name-function))
           (setq-default read-file-name-function
                         #'selectrum-read-file-name)
-          (when selectrum-do-completion-in-region
-            (setq selectrum--old-completion-in-region-function
-                  (default-value 'completion-in-region-function))
-            (setq-default completion-in-region-function
-                          #'selectrum-completion-in-region))
+          (setq selectrum--old-completion-in-region-function
+                (default-value 'completion-in-region-function))
+          (setq-default completion-in-region-function
+                          #'selectrum-completion-in-region)
           (advice-add #'completing-read-multiple :override
                       #'selectrum-completing-read-multiple)
           ;; No sharp quote because Dired may not be loaded yet.

--- a/selectrum.el
+++ b/selectrum.el
@@ -1601,7 +1601,12 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                   (nconc
                    ;; `completion-styles' is used for the initial
                    ;; filtering here internally! Selectrum doesn't use
-                   ;; `completion-styles' in other places yet.
+                   ;; `completion-styles' in other places yet. For
+                   ;; completion in region this matches the expected
+                   ;; behavior because the candidates should be
+                   ;; determined according to the sourrounding text
+                   ;; that gets completed for which
+                   ;; `completion-styles' is typically configured.
                    (completion-all-completions input collection predicate
                                                (- end start) meta)
                    nil)))


### PR DESCRIPTION
This will fix the recursive setting of `selectrum-should-sort-p` for `completion-in-region`. Also the function was written before selectrum supported handling certain metadata so I updated it to make use of the now existing handlers and also moved the handling of `:company-docsig` property into `selectrum--get-candidates-from-table` which is the appropriate place to handle this now.

While working on this I noticed that the annotations are all added at once to the whole collection, it might be faster to add them only on display for the displayed candidates. I will experiment and maybe provide another PR once this got merged.