### PR TITLE
Add display action to display candidates outside the minibuffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### Features
+* The user option `selectrum-display-action` can be used to show
+  candidates in another window or frame.
 * The user option `selectrum-show-indices` can now be a function that
   can be used to control the display of the a candidate's index ([#200]).
 * The user option `selectrum-extend-current-candidate-highlight`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 ## Unreleased
 ### Features
 * The user option `selectrum-display-action` can be used to show
-  candidates in another window or frame.
+  candidates in another window or frame ([#230]).
 * The user option `selectrum-show-indices` can now be a function that
   can be used to control the display of the a candidate's index ([#200]).
 * The user option `selectrum-extend-current-candidate-highlight`
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog].
 [#215]: https://github.com/raxod502/selectrum/pull/215
 [#220]: https://github.com/raxod502/selectrum/pull/220
 [#221]: https://github.com/raxod502/selectrum/pull/221
+[#230]: https://github.com/raxod502/selectrum/pull/230
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -265,6 +265,14 @@ matching and case-insensitive matching.
       the minibuffer to *always* have that height, even if there are
       fewer candidates. This behavior may be achieved by setting
       `selectrum-fix-minibuffer-height` to a non-nil value.
+* You can use `selectrum-display-action` to display candidates in a
+  window or frame outside the minibuffer. If you want to display the
+  whole minibuffer (including the input line) in a separate frame you
+  can use the
+  [mini-frame](https://github.com/muffinmad/emacs-mini-frame) package,
+  see the
+  [wiki](https://github.com/raxod502/selectrum/wiki/Additional-Configuration#display-minibuffer-in-a-child-frame-with-mini-frame)
+  for setup instructions.
 * The currently selected candidate is highlighted with the face
   `selectrum-current-candidate`. If you don't like the color, you can
   adjust it to taste.

--- a/selectrum.el
+++ b/selectrum.el
@@ -1003,7 +1003,7 @@ currently displayed candidates."
           (t
            (let ((window-resize-pixelwise t)
                  (window-size-fixed nil)
-                 (fit-frame-to-buffer nil)
+                 (fit-frame-to-buffer 'vertically)
                  (fit-window-to-buffer-horizontally nil))
              (fit-window-to-buffer window nil 1))))))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -950,7 +950,8 @@ Window will be created by `selectrum-display-action'."
                      'after-string minibuf-after-string)
         (cond (selectrum-display-action
                ;; Update buffer content.
-               (with-current-buffer selectrum--candidates-buffer
+               (with-current-buffer (get-buffer-create
+                                     selectrum--candidates-buffer)
                  (erase-buffer)
                  (insert candidate-string)
                  (goto-char (point-min)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -754,9 +754,11 @@ Window or frame will be created by `selectrum-display-action'."
                    (current-buffer)))))
     (or (get-buffer-window buf 'visible)
         (with-selected-window (minibuffer-selected-window)
-          (let ((window (display-buffer
+          (let ((frame (selected-frame))
+                (window (display-buffer
                          buf
                          selectrum-display-action)))
+            (select-frame-set-input-focus frame)
             (prog1 window
               (when (windowp window)
                 (with-selected-window window

--- a/selectrum.el
+++ b/selectrum.el
@@ -124,7 +124,12 @@ in a single window spanning the current frame:
 
 If this is nil the candidates are shown in the minibuffer.
 Otherwise the candidates are shown in the window as determined
-from the display action.
+from the display action. Note that if you spefify a window height
+lower than `selectrum-num-candidates-displayed' the window will
+be resized if needed to display that number of candidates. If the
+window height is higher than `selectrum-num-candidates-displayed'
+selectrum will ignore this setting and use all of the available
+height to display candidates.
 
 For the format see the ACTION argument of `display-buffer'. For
 example to display candidates in some available window use:

--- a/selectrum.el
+++ b/selectrum.el
@@ -985,7 +985,7 @@ currently displayed candidates."
                     selectrum-num-candidates-displayed)))
     (let ((window-resize-pixelwise t)
           (window-size-fixed nil)
-          (fit-frame-to-buffer 'vertically)
+          (fit-frame-to-buffer nil)
           (fit-window-to-buffer-horizontally nil))
       (fit-window-to-buffer window nil 1))))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -88,17 +88,6 @@ respected by user functions for optimal results.")
   "Regexps for determining if the prompt message includes the default value.
 See `minibuffer-default-in-prompt-regexps', from which this is derived.")
 
-(defun selectrum-display-full-frame (buf _alist)
-  "Display BUF in full frame.
-Can be used as `selectrum-display-action' to display candidates
-in a single window spanning the whole frame:
-
-    (setq selectrum-display-action
-        '(selectrum-display-full-frame)."
-  (delete-other-windows)
-  (set-window-buffer (selected-window) buf)
-  (selected-window))
-
 ;;;; User options
 
 (defgroup selectrum nil
@@ -118,6 +107,17 @@ this option also determines the maximal window height but when
 the displaying window height spans the whole frame all of the
 available height will be used for candidate display."
   :type 'number)
+
+(defun selectrum-display-full-frame (buf _alist)
+  "Display BUF in full frame.
+Can be used as `selectrum-display-action' to display candidates
+in a single window spanning the current frame:
+
+    (setq selectrum-display-action
+        '(selectrum-display-full-frame)."
+  (delete-other-windows)
+  (set-window-buffer (selected-window) buf)
+  (selected-window))
 
 (defcustom selectrum-display-action nil
   "Display action to show the candidates buffer.

--- a/selectrum.el
+++ b/selectrum.el
@@ -976,10 +976,7 @@ Window will be created by `selectrum-display-action'."
         (setq-local selectrum--init-p nil)))))
 
 (defun selectrum--update-window-height (window)
-  "Update window height of WINDOW.
-FIRST is the index of the first displayed candidate. HIGHLIGHTED
-is the index if the highlighted candidate. CANDS are the
-currently displayed candidates."
+  "Update window height of WINDOW."
   (let ((window-resize-pixelwise t)
         (window-size-fixed nil)
         (fit-frame-to-buffer 'vertically)
@@ -987,10 +984,8 @@ currently displayed candidates."
     (fit-window-to-buffer window nil 1)))
 
 (defun selectrum--update-minibuffer-height (cands)
-  "Update window height of minibuffer window.
-FIRST is the index of the first displayed candidate. HIGHLIGHTED
-is the index if the highlighted candidate. CANDS are the
-currently displayed candidates."
+  "Update window height of minibuffer window to display CANDS.
+CANDS are the currently displayed candidates."
   (when-let ((n (if selectrum-fix-minibuffer-height
                     (1+ selectrum-num-candidates-displayed)
                   (max (window-height)  ; grow only

--- a/selectrum.el
+++ b/selectrum.el
@@ -616,8 +616,6 @@ This is non-nil during the first call of
 (defvar selectrum--candidates-buffer " *selectrum*"
   "Buffer to display candidates using `selectrum-display-action'.")
 
-
-
 ;;;;; Minibuffer state utility functions
 
 (defun selectrum-get-current-candidate (&optional notfull)

--- a/selectrum.el
+++ b/selectrum.el
@@ -740,7 +740,7 @@ PRED defaults to `minibuffer-completion-predicate'."
       ('current/matches (format "%-6s " (format "%d/%d" current total)))
       (_                ""))))
 
-(defvar display-line-numbers)
+(defvar display-line-numbers) ; Undefined in Emacs 25.
 (defun selectrum--get-display-window ()
   "Get candidate display window.
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -108,13 +108,15 @@ in a single window spanning the whole frame:
   :link '(url-link "https://github.com/raxod502/selectrum"))
 
 (defcustom selectrum-num-candidates-displayed 10
-  "Maximum number of candidate lines which are displayed in the minibuffer.
-The height of the minibuffer will be this number (or the actual
-number of candidates if there are fewer candidates) plus one for
-the prompt line. If `selectrum-display-action' is non-nil this
-will also determine the window height but when the window spans
-the whole frame selectrum will automatically use all of the
-available height to display candidates."
+  "Maximum number of candidate lines which are displayed.
+Selectrum will display candidates lines up to this number or
+fewer if there are less candidates in total.
+
+For the minibuffer the window height equals this number plus one
+for the prompt line. If `selectrum-display-action' is non-nil
+this option also determines the maximal window height but when
+the displaying window height spans the whole frame all of the
+available height will be used for candidate display."
   :type 'number)
 
 (defcustom selectrum-display-action nil
@@ -135,8 +137,10 @@ Or to display them in a bottom side window:
        (side . bottom)
        (slot . -1))
 
-To use the full frame for candidate display you can use the
-provided action function `selectrum-display-full-frame'."
+Display buffer actions can also spawn a separate frame where
+candidates can be displayed. To display candidates in the current
+frame you can use the provided action function
+`selectrum-display-full-frame'."
   :type '(cons (choice function (repeat :tag "Functions" function))
                alist))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -866,9 +866,9 @@ Window or frame will be created by `selectrum-display-action'."
       (overlay-put selectrum--count-overlay
                    'priority 1)
       (setq input (or selectrum--visual-input input))
-      (let* ((window (if (and selectrum-display-action
-                                selectrum--refined-candidates)
-                         (selectrum--get-display-window)
+      (let* ((window (if selectrum-display-action
+                         (and selectrum--refined-candidates
+                              (selectrum--get-display-window))
                        (active-minibuffer-window)))
              (ncands (if (and selectrum-display-action
                               (windowp window)

--- a/selectrum.el
+++ b/selectrum.el
@@ -754,10 +754,10 @@ Window or frame will be created by `selectrum-display-action'."
                    (current-buffer)))))
     (or (get-buffer-window buf 'visible)
         (with-selected-window (minibuffer-selected-window)
-          (let ((frame (selected-frame))
-                (window (display-buffer
-                         buf
-                         selectrum-display-action)))
+          (let* ((frame (selected-frame))
+                 (window (display-buffer
+                          buf
+                          selectrum-display-action)))
             (select-frame-set-input-focus frame)
             (prog1 window
               (when (windowp window)

--- a/selectrum.el
+++ b/selectrum.el
@@ -870,7 +870,8 @@ Window will be created by `selectrum-display-action'."
       (overlay-put selectrum--count-overlay
                    'priority 1)
       (setq input (or selectrum--visual-input input))
-      (let* ((window (if selectrum-display-action
+      (let* ((windows (window-list))
+             (window (if selectrum-display-action
                          (and selectrum--refined-candidates
                               (selectrum--get-display-window))
                        (active-minibuffer-window)))
@@ -959,7 +960,9 @@ Window will be created by `selectrum-display-action'."
             (erase-buffer)
             (insert candidate-string)
             (goto-char (point-min))))
-        (when window
+        (when (and window
+                   (or (window-minibuffer-p window)
+                       (not (memq window windows))))
           (selectrum--update-window-height window
                                            first-index-displayed
                                            highlighted-index

--- a/selectrum.el
+++ b/selectrum.el
@@ -872,7 +872,8 @@ Window or frame will be created by `selectrum-display-action'."
                        (active-minibuffer-window)))
              (ncands (if (and selectrum-display-action
                               (windowp window)
-                              (= (window-height (frame-root-window))
+                              (= (window-height (frame-root-window
+                                                 (window-frame window)))
                                  (window-height window)))
                          (max (window-body-height window)
                               selectrum-num-candidates-displayed)

--- a/selectrum.el
+++ b/selectrum.el
@@ -88,27 +88,6 @@ respected by user functions for optimal results.")
   "Regexps for determining if the prompt message includes the default value.
 See `minibuffer-default-in-prompt-regexps', from which this is derived.")
 
-(defvar selectrum-display-action nil
-  "Display action to display the candidates buffer.
-
-If this is nil the candidates are shown in the minibuffer.
-Otherwise the candidates are shown in the window as determined
-from the display action.
-
-For the format see the ACTION argument of `display-buffer'. For
-example to display candidates in the current window use:
-
-    '(display-buffer-same-window)
-
-Or to display them in a bottom side window:
-
-   '(display-buffer-in-side-window
-       (side . bottom)
-       (slot . -1))
-
-To use the full frame for candidate display you can use the
-provided action function `selectrum-display-full-frame'.")
-
 (defun selectrum-display-full-frame (buf _alist)
   "Display BUF in full frame.
 Can be used as `selectrum-display-action' to display candidates
@@ -137,6 +116,29 @@ will also determine the window height but when the window spans
 the whole frame selectrum will automatically use all of the
 available height to display candidates."
   :type 'number)
+
+(defcustom selectrum-display-action nil
+  "Display action to show the candidates buffer.
+
+If this is nil the candidates are shown in the minibuffer.
+Otherwise the candidates are shown in the window as determined
+from the display action.
+
+For the format see the ACTION argument of `display-buffer'. For
+example to display candidates in the current window use:
+
+    '(display-buffer-same-window)
+
+Or to display them in a bottom side window:
+
+   '(display-buffer-in-side-window
+       (side . bottom)
+       (slot . -1))
+
+To use the full frame for candidate display you can use the
+provided action function `selectrum-display-full-frame'."
+  :type '(cons (choice function (repeat :tag "Functions" function))
+               alist))
 
 (defun selectrum-default-candidate-refine-function (input candidates)
   "Default value of `selectrum-refine-candidates-function'.

--- a/selectrum.el
+++ b/selectrum.el
@@ -114,7 +114,7 @@ Can be used as `selectrum-display-action' to display candidates
 in a single window spanning the current frame:
 
     (setq selectrum-display-action
-        '(selectrum-display-full-frame)."
+        \\='(selectrum-display-full-frame)."
   (delete-other-windows)
   (set-window-buffer (selected-window) buf)
   (selected-window))
@@ -129,11 +129,11 @@ from the display action.
 For the format see the ACTION argument of `display-buffer'. For
 example to display candidates in some available window use:
 
-    '(display-buffer-use-some-window)
+    \\='(display-buffer-use-some-window)
 
 Or to display them in a bottom side window:
 
-   '(display-buffer-in-side-window
+   \\='(display-buffer-in-side-window
        (side . bottom)
        (slot . -1))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -742,9 +742,9 @@ PRED defaults to `minibuffer-completion-predicate'."
 
 (defvar display-line-numbers)
 (defun selectrum--get-display-window ()
-  "Get candidate display window or frame.
+  "Get candidate display window.
 
-Window or frame will be created by `selectrum-display-action'."
+Window will be created by `selectrum-display-action'."
   (let ((buf (or (get-buffer selectrum--candidates-buffer)
                  (with-current-buffer
                      (get-buffer-create selectrum--candidates-buffer)

--- a/selectrum.el
+++ b/selectrum.el
@@ -989,7 +989,6 @@ Window will be created by `selectrum-display-action'."
         (window-resize
          window (- dheight wheight) nil nil 'pixelwise)))))
 
-
 (defun selectrum--ensure-single-lines (candidates)
   "Return list of single-line CANDIDATES.
 Multi-line candidates are merged into a single line. The resulting

--- a/selectrum.el
+++ b/selectrum.el
@@ -975,15 +975,15 @@ Window will be created by `selectrum-display-action'."
 FIRST is the index of the first displayed candidate. HIGHLIGHTED
 is the index if the highlighted candidate. CANDS are the
 currently displayed candidates."
-  (when (or selectrum--init-p
-            (and selectrum--current-candidate-index
-                 ;; Allow size change when navigating, not while
-                 ;; typing.
-                 (/= first highlighted)
-                 ;; Don't allow shrinking.
-                 (= (length cands)
-                    selectrum-num-candidates-displayed)))
-    (cond ((window-minibuffer-p window)
+  (cond ((window-minibuffer-p window)
+         (when (or selectrum--init-p
+                   (and selectrum--current-candidate-index
+                        ;; Allow size change when navigating, not while
+                        ;; typing.
+                        (/= first highlighted)
+                        ;; Don't allow shrinking.
+                        (= (length cands)
+                           selectrum-num-candidates-displayed)))
            (when-let ((n (if selectrum-fix-minibuffer-height
                              (1+ selectrum-num-candidates-displayed)
                            (max (window-height) ; grow only
@@ -1000,8 +1000,9 @@ currently displayed candidates."
                        (wheight (window-pixel-height win)))
                    (when (/= dheight wheight)
                      (window-resize
-                      win (- dheight wheight) nil nil 'pixelwise)))))))
-          (t
+                      win (- dheight wheight) nil nil 'pixelwise))))))))
+        (t
+         (when selectrum--init-p
            (let ((window-resize-pixelwise t)
                  (window-size-fixed nil)
                  (fit-frame-to-buffer 'vertically)

--- a/selectrum.el
+++ b/selectrum.el
@@ -751,6 +751,8 @@ Window will be created by `selectrum-display-action'."
                    (setq cursor-type nil)
                    (setq-local cursor-in-non-selected-windows nil)
                    (setq display-line-numbers nil)
+                   (setq buffer-undo-list t)
+                   (setq buffer-read-only t)
                    (setq show-trailing-whitespace nil)
                    (goto-char (point-min))
                    (current-buffer)))))

--- a/selectrum.el
+++ b/selectrum.el
@@ -127,9 +127,9 @@ Otherwise the candidates are shown in the window as determined
 from the display action.
 
 For the format see the ACTION argument of `display-buffer'. For
-example to display candidates in the current window use:
+example to display candidates in some available window use:
 
-    '(display-buffer-same-window)
+    '(display-buffer-use-some-window)
 
 Or to display them in a bottom side window:
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -763,13 +763,7 @@ Window will be created by `selectrum-display-action'."
                           buf
                           selectrum-display-action)))
             (select-frame-set-input-focus frame)
-            (prog1 window
-              (when (windowp window)
-                (with-selected-window window
-                  (set-window-hscroll window 0)
-                  (set-window-dedicated-p window t)
-                  (set-window-parameter window
-                                        'no-other-window t)))))))))
+            window)))))
 
 (defun selectrum--minibuffer-post-command-hook ()
   "Update minibuffer in response to user input."

--- a/selectrum.el
+++ b/selectrum.el
@@ -124,11 +124,11 @@ in a single window spanning the current frame:
 
 If this is nil the candidates are shown in the minibuffer.
 Otherwise the candidates are shown in the window as determined
-from the display action. Note that if you spefify a window height
+from the display action. Note that if you specify a window height
 lower than `selectrum-num-candidates-displayed' the window will
 be resized if needed to display that number of candidates. If the
 window height is higher than `selectrum-num-candidates-displayed'
-selectrum will ignore this setting and use all of the available
+Selectrum will ignore this setting and use all of the available
 height to display candidates.
 
 For the format see the ACTION argument of `display-buffer'. For
@@ -979,7 +979,7 @@ greather than the window height."
 (defun selectrum--update-window-height (window)
   "Update window height of WINDOW.
 WINDOW is the display window of current candidates and will be
-updated to fit its content vertically."
+updated to fit its content vertically if needed."
   (cond (selectrum-display-action
          (when (selectrum--expand-window-for-content-p window)
            (selectrum--update-display-window-height window)))
@@ -1001,8 +1001,9 @@ Also works for frames if WINDOW is the root window of its frame."
 
 (defun selectrum--update-minibuffer-height (window)
   "Update window height of minibuffer WINDOW.
-WINDOW height will be set to `selectrum-num-candidates-displayed'
-if `selectrum-fix-minibuffer-height' is non-nil."
+WINDOW will be updated to fit its content vertically if needed or
+will be set to `selectrum-num-candidates-displayed' if
+`selectrum-fix-minibuffer-height' is non-nil."
   (if selectrum-fix-minibuffer-height
       (let ((n (1+ selectrum-num-candidates-displayed)))
         (with-selected-window window

--- a/selectrum.el
+++ b/selectrum.el
@@ -103,8 +103,8 @@ fewer if there are less candidates in total.
 
 For the minibuffer the window height equals this number plus one
 for the prompt line. If `selectrum-display-action' is non-nil
-this option also determines the maximal window height but when
-the displaying window height spans the whole frame all of the
+this option determines the maximal window height but when the
+displaying window height is greater than that all of the
 available height will be used for candidate display."
   :type 'number)
 
@@ -875,10 +875,7 @@ Window will be created by `selectrum-display-action'."
                               (selectrum--get-display-window))
                        (active-minibuffer-window)))
              (ncands (if (and selectrum-display-action
-                              (windowp window)
-                              (= (window-height (frame-root-window
-                                                 (window-frame window)))
-                                 (window-height window)))
+                              (windowp window))
                          (max (window-body-height window)
                               selectrum-num-candidates-displayed)
                        selectrum-num-candidates-displayed))

--- a/selectrum.el
+++ b/selectrum.el
@@ -742,15 +742,16 @@ PRED defaults to `minibuffer-completion-predicate'."
 (defun selectrum--get-window-or-frame ()
   "Get candidate display window or frame.
 
-Window will be initialized using `selectrum-display-action'."
-  (let ((buf (with-current-buffer
-                 (get-buffer-create selectrum--candidates-buffer)
-               (setq cursor-type nil)
-               (setq-local cursor-in-non-selected-windows nil)
-               (setq display-line-numbers nil)
-               (setq show-trailing-whitespace nil)
-               (goto-char (point-min))
-               (current-buffer))))
+Window or frame will be created by `selectrum-display-action'."
+  (let ((buf (or (get-buffer selectrum--candidates-buffer)
+                 (with-current-buffer
+                     (get-buffer-create selectrum--candidates-buffer)
+                   (setq cursor-type nil)
+                   (setq-local cursor-in-non-selected-windows nil)
+                   (setq display-line-numbers nil)
+                   (setq show-trailing-whitespace nil)
+                   (goto-char (point-min))
+                   (current-buffer)))))
     (or (get-buffer-window buf)
         (with-selected-window (minibuffer-selected-window)
           (let ((window-or-frame (display-buffer


### PR DESCRIPTION
This adds the ability to configure a display action via `selectrum-display-action` to display candidates in a window outside the minibuffer as suggested in #227. 
