### PR TITLE
Initialize selectrum after all other functions in minibuffer-setup-hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ The format is based on [Keep a Changelog].
   candidates ([#200]).
 
 ### Bugs fixed
-* `selectrum-should-sort-p` can now be locally set using
-   `minibuffer-with-setup-hook` to disable sorting for a single
-   `selectrum-read` session ([#242]).
+* Selectrums internal minibuffer setup hook now runs after any other
+  functions added to `minibuffer-setup-hook`. Before, you couldn't set
+  `selectrum-should-sort-p` locally via `minibuffer-with-setup-hook`
+  to adjust sorting for a single `selectrum-read` session ([#242]).
 * `selectrum-completion-in-region` no longer unsets
   `selectrum-should-sort-p` for all recursive minibuffer sessions in
   the case the initial completion table specified its own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog].
   candidates ([#200]).
 
 ### Bugs fixed
-* Selectrums internal minibuffer setup hook now runs after any other
+* Selectrum's internal minibuffer setup hook now runs after any other
   functions added to `minibuffer-setup-hook`. Before, you couldn't set
   `selectrum-should-sort-p` locally via `minibuffer-with-setup-hook`
   to adjust sorting for a single `selectrum-read` session ([#242]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog].
   candidates ([#200]).
 
 ### Bugs fixed
+* `selectrum-should-sort-p` can now be locally set using
+   `minibuffer-with-setup-hook` to disable sorting for a single
+   `selectrum-read` session ([#242]).
 * `selectrum-completion-in-region` no longer unsets
   `selectrum-should-sort-p` for all recursive minibuffer sessions in
   the case the initial completion table specified its own
@@ -42,6 +45,7 @@ The format is based on [Keep a Changelog].
 [#215]: https://github.com/raxod502/selectrum/pull/215
 [#220]: https://github.com/raxod502/selectrum/pull/220
 [#221]: https://github.com/raxod502/selectrum/pull/221
+[#242]: https://github.com/raxod502/selectrum/pull/242
 [#230]: https://github.com/raxod502/selectrum/pull/230
 
 ## 3.0 (released 2020-10-20)

--- a/README.md
+++ b/README.md
@@ -445,7 +445,9 @@ user option:
   preprocessing it wants). Usually preprocessing only happens once.
   However, if a function is passed to `selectrum-read` to generate the
   candidate list dynamically based on the user input, then
-  preprocessing happens instead after each input change.
+  preprocessing happens instead after each input change. For examples
+  how to configure sorting for `completing-read` collections see the
+  [wiki](https://github.com/raxod502/selectrum/wiki/Tips-for-Creating-Commands).
 * `selectrum-refine-candidates-function` takes the preprocessed list
   and filters it using the user's input. This refinement happens every
   time the user input is updated.

--- a/README.md
+++ b/README.md
@@ -445,9 +445,7 @@ user option:
   preprocessing it wants). Usually preprocessing only happens once.
   However, if a function is passed to `selectrum-read` to generate the
   candidate list dynamically based on the user input, then
-  preprocessing happens instead after each input change. For examples
-  how to configure sorting for `completing-read` collections see the
-  [wiki](https://github.com/raxod502/selectrum/wiki/Tips-for-Creating-Commands).
+  preprocessing happens instead after each input change.
 * `selectrum-refine-candidates-function` takes the preprocessed list
   and filters it using the user's input. This refinement happens every
   time the user input is updated.


### PR DESCRIPTION
When using `completing-read` sorting can be configured/disabled by providing `display-sort-function` via the metadata. To correctly disable sorting for `selectrum-read` one needs to set it in `minibuffer-setup-hook` like this:

```elisp
(minibuffer-with-setup-hook
    (lambda ()
      (setq-local selectrum-should-sort-p nil))
  (selectrum-read "Switch to: " 
                  '("longest" "longer" "short")))
```

Before this PR this doesn't actually work because `selectrum--minibuffer-setup-hook` runs before the temporary hook added above. Alternatively we could use `(:append (lambda ...))` for `selectrum-read` but this might cause unexpected side effects for existing code which assumes `selectrum-read` runs early, we also have such code in selectrum itself (see `selectrum-read-file-name`). Because of that I moved the sorting code into `selectrum--minibuffer-post-command-hook` which seems like the simplest fix without breaking anything due to changed behaviour.