### PR TITLE
only set annotation face if string does not yet have a face

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -483,9 +483,11 @@ metadata."
   ;; Rule out situations where the annotation
   ;; is nil.
   (when-let ((annotation (funcall annotation-func string)))
-    (propertize
-     annotation
-     'face 'selectrum-completion-annotation)))
+    (if (text-property-not-all 0 (length annotation) 'face nil annotation)
+        annotation
+      (propertize
+       annotation
+       'face 'selectrum-completion-annotation))))
 
 (defun selectrum--get-margin-docsig (string docsig-func)
   "Get `selectrum-candidate-display-right-margin' value for docsig.


### PR DESCRIPTION
@clemera This works for me, see #247. The question is only if this is robust enough. Are there commands where we want to overwrite the face in any case? But why should a command return a propertized string if it wouldn't want the properties to be used?

However it seems that the \*Completions\* buffer always merges the faces which is unfortunate (for example if I use describe-face with marginalia-mode enabled and with selectrum-mode disabled). I don't know what we should do here. The conclusion might be that we cannot use the Emacs annotation function in marginalia for selectrum? I don't know. Ping @oantolin