### PR TITLE
Select initial input when it equals the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,6 @@ The format is based on [Keep a Changelog].
   candidates to the history ([#212], [#213]).
 * Selectrum now by default shows indices relative to displayed
   candidates ([#200]).
-* Selectrum now uses the `initial-input` argument passed to
-  `completing-read` which was ignored before ([#253]).
 * The prompt gets initially selected now when it equals the default
   value. This aligns with Selectrum's behavior of sorting the default
   first and will also make such prompts behave like in default Emacs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog].
 * Selectrum now uses the `initial-input` argument passed to
   `completing-read` which was ignored before. The prompt gets
   initially selected when it equals the default value. This aligns
-  with Selectrum's behaviour of sorting the default first and will
+  with Selectrum's behavior of sorting the default first and will
   also make such prompts behave like in default Emacs completion where
   you can immediately submit the initial input ([#253]).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ The format is based on [Keep a Changelog].
 [#236]: https://github.com/raxod502/selectrum/issues/236
 [#250]: https://github.com/raxod502/selectrum/pull/250
 [#251]: https://github.com/raxod502/selectrum/pull/251
+[#253]: https://github.com/raxod502/selectrum/pull/253
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,12 @@ The format is based on [Keep a Changelog].
 * Selectrum now by default shows indices relative to displayed
   candidates ([#200]).
 * Selectrum now uses the `initial-input` argument passed to
-  `completing-read` which was ignored before. The prompt gets
-  initially selected when it equals the default value. This aligns
-  with Selectrum's behavior of sorting the default first and will
-  also make such prompts behave like in default Emacs completion where
-  you can immediately submit the initial input ([#253]).
+  `completing-read` which was ignored before ([#253]).
+* The prompt gets initially selected now when it equals the default
+  value. This aligns with Selectrum's behavior of sorting the default
+  first and will also make such prompts behave like in default Emacs
+  completion where you can immediately submit the initial input
+  ([#253]).
 
 ### Bugs fixed
 * The return value of `selectrum-completion-in-region` has been fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ The format is based on [Keep a Changelog].
   candidates ([#200]).
 * Selectrum now uses the `initial-input` argument passed to
   `completing-read` which was ignored before. The prompt gets
-  initially selected when it equals the default value. This will make
-  prompts behave more like in default Emacs completion where you can
-  submit it initially with `RET` ([#253]).
+  initially selected when it equals the default value. This aligns
+  with Selectrum's behaviour of sorting the default first and will
+  also make such prompts behave like in default Emacs completion where
+  you can immediately submit the initial input ([#253]).
 
 ### Bugs fixed
 * The return value of `selectrum-completion-in-region` has been fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ The format is based on [Keep a Changelog].
   candidates to the history ([#212], [#213]).
 * Selectrum now by default shows indices relative to displayed
   candidates ([#200]).
+* Selectrum now uses the `initial-input` argument passed to
+  `completing-read` which was ignored before. The prompt gets
+  initially selected when it equals the default value. This will make
+  prompts behave more like in default Emacs completion where you can
+  submit it initially with `RET` ([#253]).
 
 ### Bugs fixed
 * The return value of `selectrum-completion-in-region` has been fixed

--- a/selectrum.el
+++ b/selectrum.el
@@ -803,13 +803,8 @@ greather than the window height."
                                     selectrum--refined-candidates)))
                   -1)
                  ((and selectrum--init-p
-                       minibuffer-completing-file-name
-                       (eq minibuffer-completion-predicate
-                           'file-directory-p)
-                       (equal (minibuffer-contents)
-                              selectrum--default-candidate))
-                  ;; When reading directories and the default is the
-                  ;; prompt, select it initially.
+                       (equal selectrum--default-candidate
+                              (minibuffer-contents)))
                   -1)
                  (selectrum--move-default-candidate-p
                   0)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1575,7 +1575,9 @@ HIST, DEF, and INHERIT-INPUT-METHOD, see `completing-read'."
   (ignore initial-input inherit-input-method)
   (selectrum-read
    prompt nil
-   :initial-input initial-input
+   ;; Don't pass `initial-input'. We use it internally but it's
+   ;; deprecated in `completing-read' and doesn't work well with the
+   ;; Selectrum paradigm except in specific cases that we control.
    :default-candidate (or (car-safe def) def)
    :require-match (eq require-match t)
    :history hist

--- a/selectrum.el
+++ b/selectrum.el
@@ -1185,22 +1185,20 @@ TABLE defaults to `minibuffer-completion-table'. PRED defaults to
   (setq selectrum--count-overlay nil))
 
 (cl-defun selectrum--minibuffer-setup-hook
-    (candidates &key default-candidate initial-input)
+    (candidates &key default-candidate)
   "Set up minibuffer for interactive candidate selection.
 CANDIDATES is the list of strings that was passed to
 `selectrum-read'. DEFAULT-CANDIDATE, if provided, is added to the
-list and sorted first. INITIAL-INPUT, if provided, is inserted
-into the user input area to start with."
+list and sorted first."
   (add-hook
    'minibuffer-exit-hook #'selectrum--minibuffer-exit-hook nil 'local)
   (setq-local selectrum--init-p t)
+  (when selectrum--repeat
+    (delete-minibuffer-contents)
+    (insert selectrum--previous-input-string))
   (unless selectrum--candidates-overlay
     (setq selectrum--candidates-overlay
           (make-overlay (point) (point) nil 'front-advance 'rear-advance)))
-  (if selectrum--repeat
-      (insert selectrum--previous-input-string)
-    (when initial-input
-      (insert initial-input)))
   ;; If metadata specifies a custom sort function use it as
   ;; `selectrum-preprocess-candidates-function' for this session.
   (when-let ((sortf (selectrum--get-meta 'display-sort-function)))
@@ -1548,8 +1546,7 @@ semantics of `cl-defun'."
         (:append (lambda ()
                    (selectrum--minibuffer-setup-hook
                     candidates
-                    :default-candidate default-candidate
-                    :initial-input initial-input)))
+                    :default-candidate default-candidate)))
       (let* ((minibuffer-allow-text-properties t)
              (resize-mini-windows 'grow-only)
              (max-mini-window-height
@@ -1559,7 +1556,7 @@ semantics of `cl-defun'."
              (icomplete-mode nil)
              (selectrum-active-p t)
              (res (read-from-minibuffer
-                   prompt nil selectrum-minibuffer-map nil
+                   prompt initial-input selectrum-minibuffer-map nil
                    (or history 'minibuffer-history))))
         (cond (minibuffer-completion-table
                ;; Behave like completing-read-default which strips the text
@@ -1583,9 +1580,7 @@ HIST, DEF, and INHERIT-INPUT-METHOD, see `completing-read'."
   (ignore initial-input inherit-input-method)
   (selectrum-read
    prompt nil
-   ;; Don't pass `initial-input'. We use it internally but it's
-   ;; deprecated in `completing-read' and doesn't work well with the
-   ;; Selectrum paradigm except in specific cases that we control.
+   :initial-input initial-input
    :default-candidate (or (car-safe def) def)
    :require-match (eq require-match t)
    :history hist


### PR DESCRIPTION
Selectrums setup hook runs late now using `(:append...)`, see #242. This is a problem for use cases which assume the initial input is present from the start. Instead of handling it manually this PR passes the initial-input argument to `read-from-minibuffer` so the input is present from the start as it should be the case. For `selectrum-repeat` it is important to have exactly the same input as in the last session, this can be ensured by keep running it late and restoring the minibuffer content there so I left it in setup hook.

~~In addition to that I added support for the `initial-input` argument of `completing-read` which is deprecated but for backward compatibility  reasons I don't see how this could ever get removed. The comment noted that the initial-input argument does not work well with the selectrum paradigm, I think this was before the concept of a selected prompt was introduced. If we select the prompt initially the usage pattern is the same as in default Emacs.~~ (moved to #254)

I changed the behaviour so the prompt now gets selected when the initial input equals the default candidate. This will also affect file completions where we had some complaints that it doesn't work like in default Emacs which this will fix: `C-x C-f RET` now opens the current directory as with default completion because the prompt will be selected initially. When navigating through path levels you still get the convenience of prescient sorting the most recent used ones to the top so I think this a good compromise.



