### PR TITLE
Support initial-input argument of completing-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog].
   candidates to the history ([#212], [#213]).
 * Selectrum now by default shows indices relative to displayed
   candidates ([#200]).
+* Selectrum now uses the `initial-input` argument passed to
+  `completing-read` which was ignored before ([#253]).
 
 ### Bugs fixed
 * The return value of `selectrum-completion-in-region` has been fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog].
 * Selectrum now by default shows indices relative to displayed
   candidates ([#200]).
 * Selectrum now uses the `initial-input` argument passed to
-  `completing-read` which was ignored before ([#253]).
+  `completing-read` which was ignored before ([#254]).
 
 ### Bugs fixed
 * The return value of `selectrum-completion-in-region` has been fixed
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog].
 [#236]: https://github.com/raxod502/selectrum/issues/236
 [#250]: https://github.com/raxod502/selectrum/pull/250
 [#251]: https://github.com/raxod502/selectrum/pull/251
+[#254]: https://github.com/raxod502/selectrum/pull/254
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1626,7 +1626,7 @@ semantics of `cl-defun'."
   "Read choice using Selectrum. Can be used as `completing-read-function'.
 For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
 HIST, DEF, and INHERIT-INPUT-METHOD, see `completing-read'."
-  (ignore initial-input inherit-input-method)
+  (ignore inherit-input-method)
   (selectrum-read
    prompt nil
    :initial-input initial-input

--- a/selectrum.el
+++ b/selectrum.el
@@ -1583,9 +1583,7 @@ HIST, DEF, and INHERIT-INPUT-METHOD, see `completing-read'."
   (ignore initial-input inherit-input-method)
   (selectrum-read
    prompt nil
-   ;; Don't pass `initial-input'. We use it internally but it's
-   ;; deprecated in `completing-read' and doesn't work well with the
-   ;; Selectrum paradigm except in specific cases that we control.
+   :initial-input initial-input
    :default-candidate (or (car-safe def) def)
    :require-match (eq require-match t)
    :history hist


### PR DESCRIPTION
Add initial-input support for `completing-read`. Originated from #253.
