### PR TITLE
Use internal property for directory suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ The format is based on [Keep a Changelog].
   it's a list of strings. Before the list only wasn't modfied when the
   function returned the alist format as specified by `selectrum-read`
   ([#220]).
+* Annotations or usage or `selectrum-candidate-display-suffix`
+  property in file completions were overwritten for directories and
+  not displayed, which has been fixed ([#256], [#255]).
 
 [#194]: https://github.com/raxod502/selectrum/issues/194
 [#200]: https://github.com/raxod502/selectrum/pull/200
@@ -62,6 +65,8 @@ The format is based on [Keep a Changelog].
 [#250]: https://github.com/raxod502/selectrum/pull/250
 [#251]: https://github.com/raxod502/selectrum/pull/251
 [#253]: https://github.com/raxod502/selectrum/pull/253
+[#255]: https://github.com/raxod502/selectrum/issues/255
+[#256]: https://github.com/raxod502/selectrum/pull/256
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1085,7 +1085,10 @@ TABLE defaults to `minibuffer-completion-table'. PRED defaults to
                         0 'selectrum-candidate-display-prefix
                         candidate))
                (isuffix (get-text-property
-                         0 'selectrum--candidate-display-suffix
+                         ;; Internal property to display an additional
+                         ;; suffix before the actual suffix added via
+                         ;; public API.
+                         0 'selectrum--internal-candidate-display-suffix
                          candidate))
                (suffix (or (get-text-property
                             0 'selectrum-candidate-display-suffix
@@ -1791,7 +1794,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                         (setq i (substring i 0 (1- (length i))))
                         (put-text-property
                          0 (length i)
-                         'selectrum--candidate-display-suffix
+                         'selectrum--internal-candidate-display-suffix
                          "/"
                          i))
                       i)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1084,6 +1084,9 @@ TABLE defaults to `minibuffer-completion-table'. PRED defaults to
         (let* ((prefix (get-text-property
                         0 'selectrum-candidate-display-prefix
                         candidate))
+               (isuffix (get-text-property
+                         0 'selectrum--candidate-display-suffix
+                         candidate))
                (suffix (or (get-text-property
                             0 'selectrum-candidate-display-suffix
                             candidate)
@@ -1093,7 +1096,7 @@ TABLE defaults to `minibuffer-completion-table'. PRED defaults to
                                  candidate
                                  'selectrum-completion-annotation))))
                (displayed-candidate
-                (concat prefix candidate suffix))
+                (concat prefix candidate isuffix suffix))
                (right-margin
                 (or (get-text-property
                      0 'selectrum-candidate-display-right-margin
@@ -1788,7 +1791,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                         (setq i (substring i 0 (1- (length i))))
                         (put-text-property
                          0 (length i)
-                         'selectrum-candidate-display-suffix
+                         'selectrum--candidate-display-suffix
                          "/"
                          i))
                       i)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1087,7 +1087,9 @@ TABLE defaults to `minibuffer-completion-table'. PRED defaults to
                (isuffix (get-text-property
                          ;; Internal property to display an additional
                          ;; suffix before the actual suffix added via
-                         ;; public API.
+                         ;; public API. Currently only used for
+                         ;; displaying slashes of directories in file
+                         ;; completions.
                          0 'selectrum--internal-candidate-display-suffix
                          candidate))
                (suffix (or (get-text-property


### PR DESCRIPTION
Using `selectrum-candidate-display-suffix` overrides any annotations or usages of that property from the calling side so I switched to use an internal property for the special purpose of displaying the directory slashes. See #255. 