### PR TITLE
Make use of completion boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ The format is based on [Keep a Changelog].
   first and will also make such prompts behave like in default Emacs
   completion where you can immediately submit the initial input
   ([#253]).
+* In file completions you get completion for environmental variables
+  and for individual path levels now. By typing "$" after path
+  separator you get queried for the variable name. To change a
+  sublevel with completion you can navigate into the file path prompt
+  and start editing the path level.
 
 ### Bugs fixed
 * The return value of `selectrum-completion-in-region` has been fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog].
   and for individual path levels now. By typing "$" after path
   separator you get queried for the variable name. To change a
   sublevel with completion you can navigate into the file path prompt
-  and start editing the path level.
+  and start editing the path level ([#258]).
 
 ### Bugs fixed
 * The return value of `selectrum-completion-in-region` has been fixed
@@ -72,6 +72,7 @@ The format is based on [Keep a Changelog].
 [#253]: https://github.com/raxod502/selectrum/pull/253
 [#255]: https://github.com/raxod502/selectrum/issues/255
 [#256]: https://github.com/raxod502/selectrum/pull/256
+[#258]: https://github.com/raxod502/selectrum/pull/258
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -655,16 +655,14 @@ The current matchstring may be surrounded by prefix and suffix."
                   (substring input 0 pt)
                   minibuffer-completion-table
                   minibuffer-completion-predicate
+                  ;; Workaround error for /|/.
                   (if (and minibuffer-completing-file-name
                            (looking-back "/" (1- (point)))
                            (looking-at "/"))
                       ""
                     (substring input pt))))
-         (start (+ mpe
-                   (if (and minibuffer-completing-file-name
-                            (looking-back "~/" mpe))
-                       (length input)
-                     (car bounds))))
+         ;; FIXME: Bound is wrong for shadowed ~/ path.
+         (start (+ mpe (car bounds)))
          (end (+ mpe (+ pt (cdr bounds)))))
     (cons start end)))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -661,7 +661,6 @@ The current matchstring may be surrounded by prefix and suffix."
                            (looking-at "/"))
                       ""
                     (substring input pt))))
-         ;; FIXME: Bound is wrong for shadowed ~/ path.
          (start (+ mpe (car bounds)))
          (end (+ mpe (+ pt (cdr bounds)))))
     (cons start end)))
@@ -770,7 +769,6 @@ greather than the window height."
           (buffer-undo-list t)
           (input (buffer-substring (minibuffer-prompt-end)
                                    (point-max)))
-          (bound (point-max))
           (keep-mark-active (not deactivate-mark)))
       (unless (equal input selectrum--previous-input-string)
         (when (and (not selectrum--preprocessed-candidates)
@@ -902,7 +900,7 @@ greather than the window height."
                             (not minibuffer-completing-file-name)
                             (not (member selectrum--default-candidate
                                          selectrum--refined-candidates))))
-                   (if (= (minibuffer-prompt-end) bound)
+                   (if (= (minibuffer-prompt-end) (point-max))
                        (format " %s %s%s"
                                (propertize
                                 "[default value:"
@@ -923,11 +921,11 @@ greather than the window height."
                                 (< highlighted-index 0))
                        (prog1 nil
                          (add-text-properties
-                          (minibuffer-prompt-end) bound
+                          (minibuffer-prompt-end) (point-max)
                           '(face selectrum-current-candidate)))))
                  (prog1 nil
                    (remove-text-properties
-                    (minibuffer-prompt-end) bound
+                    (minibuffer-prompt-end) (point-max)
                     '(face selectrum-current-candidate)))))
              (minibuf-after-string (or default " ")))
         (if selectrum-display-action
@@ -1820,12 +1818,11 @@ PREDICATE, see `read-buffer'."
 For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
             HIST, DEF, _INHERIT-INPUT-METHOD see `completing-read'."
   (let ((coll
-         (lambda (_input)
+         (lambda (input)
            (let* ((bounds (selectrum--minibuffer-matchstring-bounds))
                   (pathprefix (buffer-substring
                                (minibuffer-prompt-end) (car bounds)))
-                  (matchstr (buffer-substring
-                             (car bounds) (cdr bounds)))
+                  (matchstr (file-name-nondirectory input))
                   (cands
                    (condition-case _
                        (funcall collection pathprefix

--- a/selectrum.el
+++ b/selectrum.el
@@ -1832,10 +1832,11 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                      (buffer-substring
                       (minibuffer-prompt-end) (car bounds))))
                   (matchstr
-                   ;; Bounds are off for ~/ pathe shadows for some
-                   ;; reason.
-                   (if (or (and (equal pathprefix "~/") (eobp))
-                           (and (string-suffix-p "$" input) (eobp)))
+                   (if (and (eobp)
+                            ;; Bounds are off for ~/ pathe shadows for
+                            ;; some reason.
+                            (or (equal pathprefix "~/")
+                                (string-suffix-p "$" input)))
                        (file-name-nondirectory input)
                      (buffer-substring (car bounds) (cdr bounds))))
                   (cands

--- a/selectrum.el
+++ b/selectrum.el
@@ -1822,10 +1822,15 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
             HIST, DEF, _INHERIT-INPUT-METHOD see `completing-read'."
   (let ((coll
          (lambda (input)
-           (let* ((bounds (selectrum--minibuffer-matchstring-bounds))
-                  (pathprefix (buffer-substring
-                               (minibuffer-prompt-end) (car bounds)))
-                  (matchstr (file-name-nondirectory input))
+           (let* ((matchstr (file-name-nondirectory input))
+                  (pathprefix
+                   (if (or (not (string-suffix-p "$" matchstr))
+                           (string= "$" matchstr))
+                       (let ((bounds
+                              (selectrum--minibuffer-matchstring-bounds)))
+                         (buffer-substring
+                          (minibuffer-prompt-end) (car bounds)))
+                     (or (file-name-directory input) "")))
                   (cands
                    (condition-case _
                        (funcall collection pathprefix

--- a/selectrum.el
+++ b/selectrum.el
@@ -676,6 +676,11 @@ The current matchstring may be surrounded by prefix and suffix."
                (prefix (buffer-substring
                         (minibuffer-prompt-end) (car bounds)))
                (suffix (buffer-substring (cdr bounds) (point-max))))
+          (when (and minibuffer-completing-file-name
+                     (not (string-empty-p suffix))
+                     (string-match "/\\'" candidate)
+                     (string-match "\\`/" suffix))
+            (setq suffix (substring suffix 1)))
           (concat prefix candidate suffix)))
       candidate))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -1445,7 +1445,11 @@ indices."
           (apply
            #'run-hook-with-args
            'selectrum-candidate-inserted-hook
-           candidate selectrum--read-args))
+           candidate selectrum--read-args)
+          ;; Ensure refresh of UI as the input string might be the
+          ;; same but current candidates might have come from sub path
+          ;; completion.
+          (setq selectrum--previous-input-string nil))
       (unless completion-fail-discreetly
         (ding)
         (minibuffer-message "No match")))))

--- a/selectrum.el
+++ b/selectrum.el
@@ -812,6 +812,7 @@ greather than the window height."
                  selectrum--refined-candidates)))
         (setq selectrum--refined-candidates
               (selectrum--move-to-front-destructive
+               ;; Make sure matching dirnames are sorted first.
                (if (and minibuffer-completing-file-name
                         (member (file-name-as-directory input)
                                 selectrum--refined-candidates))

--- a/selectrum.el
+++ b/selectrum.el
@@ -599,7 +599,8 @@ This is non-nil during the first call of
 (defun selectrum-get-current-candidate (&optional notfull)
   "Return currently selected Selectrum candidate.
 If NOTFULL is non-nil don't use canonical representation of
-candidate as per `selectrum-candidate-full' text property."
+candidate as per `selectrum-candidate-full' text property or
+determined by current `completion-boundaries'."
   (when (and selectrum-active-p
              selectrum--current-candidate-index)
     (if notfull
@@ -612,7 +613,8 @@ candidate as per `selectrum-candidate-full' text property."
 (defun selectrum-get-current-candidates (&optional notfull)
   "Get list of current Selectrum candidates.
 If NOTFULL is non-nil don't use canonical representation of
-candidates as per `selectrum-candidate-full' text property."
+candidates as per `selectrum-candidate-full' text property or
+determined by current `completion-boundaries'."
   (when (and selectrum-active-p
              selectrum--refined-candidates)
     (if notfull

--- a/selectrum.el
+++ b/selectrum.el
@@ -1826,6 +1826,8 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                   (pathprefix (buffer-substring
                                (minibuffer-prompt-end) (car bounds)))
                   (matchstr
+                   ;; Bounds are off for ~/ pathe shadows for some
+                   ;; reason.
                    (if (and (equal pathprefix "~/") (eobp))
                        (file-name-nondirectory input)
                      (buffer-substring (car bounds) (cdr bounds))))

--- a/selectrum.el
+++ b/selectrum.el
@@ -668,14 +668,14 @@ The current matchstring may be surrounded by prefix and suffix."
 (defun selectrum--get-full (candidate)
   "Get full form of CANDIDATE."
   (or (get-text-property 0 'selectrum-candidate-full candidate)
-      (when minibuffer-completion-table
+      (when (and minibuffer-completion-table
+                 minibuffer-completing-file-name)
         (let* ((bounds (selectrum--minibuffer-matchstring-bounds))
                (prefix (buffer-substring
                         (minibuffer-prompt-end) (car bounds)))
                (promptp (and (eobp) (equal prefix candidate)))
                (suffix (buffer-substring (cdr bounds) (point-max)))
-               (candidate (if (and minibuffer-completing-file-name
-                                   (not (string-empty-p suffix)))
+               (candidate (if (not (string-empty-p suffix))
                               (directory-file-name candidate)
                             candidate)))
           (concat (unless promptp prefix) candidate suffix)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -646,7 +646,7 @@ behavior."
         (setq-local selectrum--skip-updates-p t)))))
 
 (defun selectrum--minibuffer-matchstring-bounds ()
-  "Return bounds for current matchstring.
+  "Return bounds for current matchstring as per `completion-boundaries'.
 The current matchstring may be surrounded by prefix and suffix."
   (let* ((input (minibuffer-contents))
          (mpe (minibuffer-prompt-end))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1823,12 +1823,19 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
   (let ((coll
          (lambda (input)
            (let* ((bounds (selectrum--minibuffer-matchstring-bounds))
-                  (pathprefix (buffer-substring
-                               (minibuffer-prompt-end) (car bounds)))
+                  (pathprefix
+                   ;; Allow matching $ as regexp at end of input.
+                   (if (and (eobp)
+                            (string-suffix-p "$" input)
+                            (not (string-suffix-p "/$" input)))
+                       (or (file-name-directory input) "")
+                     (buffer-substring
+                      (minibuffer-prompt-end) (car bounds))))
                   (matchstr
                    ;; Bounds are off for ~/ pathe shadows for some
                    ;; reason.
-                   (if (and (equal pathprefix "~/") (eobp))
+                   (if (or (and (equal pathprefix "~/") (eobp))
+                           (and (string-suffix-p "$" input) (eobp)))
                        (file-name-nondirectory input)
                      (buffer-substring (car bounds) (cdr bounds))))
                   (cands

--- a/selectrum.el
+++ b/selectrum.el
@@ -672,11 +672,13 @@ The current matchstring may be surrounded by prefix and suffix."
         (let* ((bounds (selectrum--minibuffer-matchstring-bounds))
                (prefix (buffer-substring
                         (minibuffer-prompt-end) (car bounds)))
-               (suffix (buffer-substring (cdr bounds) (point-max))))
-          (when (and minibuffer-completing-file-name
-                     (not (string-empty-p suffix)))
-            (setq candidate (directory-file-name candidate)))
-          (concat prefix candidate suffix)))
+               (promptp (and (eobp) (equal prefix candidate)))
+               (suffix (buffer-substring (cdr bounds) (point-max)))
+               (candidate (if (and minibuffer-completing-file-name
+                                   (not (string-empty-p suffix)))
+                              (directory-file-name candidate)
+                            candidate)))
+          (concat (unless promptp prefix) candidate suffix)))
       candidate))
 
 (defun selectrum--get-candidate (index)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1822,11 +1822,11 @@ PREDICATE, see `read-buffer'."
 For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
             HIST, DEF, _INHERIT-INPUT-METHOD see `completing-read'."
   (let ((coll
-         (lambda (_input)
+         (lambda (input)
            (let* ((bounds (selectrum--minibuffer-matchstring-bounds))
                   (pathprefix (buffer-substring
                                (minibuffer-prompt-end) (car bounds)))
-                  (matchstr (buffer-substring (car bounds) (cdr bounds)))
+                  (matchstr (file-name-nondirectory input))
                   (cands
                    (selectrum--map-destructive
                     (lambda (i)

--- a/selectrum.el
+++ b/selectrum.el
@@ -675,10 +675,8 @@ The current matchstring may be surrounded by prefix and suffix."
                         (minibuffer-prompt-end) (car bounds)))
                (suffix (buffer-substring (cdr bounds) (point-max))))
           (when (and minibuffer-completing-file-name
-                     (not (string-empty-p suffix))
-                     (string-match "/\\'" candidate)
-                     (string-match "\\`/" suffix))
-            (setq suffix (substring suffix 1)))
+                     (not (string-empty-p suffix)))
+            (setq candidate (directory-file-name candidate)))
           (concat prefix candidate suffix)))
       candidate))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -1827,15 +1827,15 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                              (car bounds) (cdr bounds)))
                   (cands
                    (condition-case _
-                        (funcall collection pathprefix
-                                 (lambda (i)
-                                   (and (not (member i '("./" "../")))
-                                        (or (not predicate)
-                                            (funcall predicate i))))
-                                 t)
-                      ;; May happen in case user quits out
-                      ;; of a TRAMP prompt.
-                      (quit))))
+                       (funcall collection pathprefix
+                                (lambda (i)
+                                  (and (not (member i '("./" "../")))
+                                       (or (not predicate)
+                                           (funcall predicate i))))
+                                t)
+                     ;; May happen in case user quits out
+                     ;; of a TRAMP prompt.
+                     (quit))))
              `((input . ,matchstr)
                (candidates . ,cands))))))
     (selectrum-read

--- a/selectrum.el
+++ b/selectrum.el
@@ -1822,15 +1822,13 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
             HIST, DEF, _INHERIT-INPUT-METHOD see `completing-read'."
   (let ((coll
          (lambda (input)
-           (let* ((matchstr (file-name-nondirectory input))
-                  (pathprefix
-                   (if (or (not (string-suffix-p "$" matchstr))
-                           (string= "$" matchstr))
-                       (let ((bounds
-                              (selectrum--minibuffer-matchstring-bounds)))
-                         (buffer-substring
-                          (minibuffer-prompt-end) (car bounds)))
-                     (or (file-name-directory input) "")))
+           (let* ((bounds (selectrum--minibuffer-matchstring-bounds))
+                  (pathprefix (buffer-substring
+                               (minibuffer-prompt-end) (car bounds)))
+                  (matchstr
+                   (if (and (equal pathprefix "~/") (eobp))
+                       (file-name-nondirectory input)
+                     (buffer-substring (car bounds) (cdr bounds))))
                   (cands
                    (condition-case _
                        (funcall collection pathprefix

--- a/selectrum.el
+++ b/selectrum.el
@@ -1833,7 +1833,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                       (minibuffer-prompt-end) (car bounds))))
                   (matchstr
                    (if (and (eobp)
-                            ;; Bounds are off for ~/ pathe shadows for
+                            ;; Bounds are off for ~/ path shadows for
                             ;; some reason.
                             (or (equal pathprefix "~/")
                                 (string-suffix-p "$" input)))


### PR DESCRIPTION
This enables sub path completion and env variable completion using `completion-boundaries`. Thanks @oantolin helping me to understand `completion-boundaries`.