### PR TITLE
Improve completion in region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog].
 * The user option `selectrum-extend-current-candidate-highlight`
   determines whether to extend the highlighting of the current
   candidate until the margin (the default is nil). See [#208].
+* The user option `selectrum-complete-in-buffer` can be used to
+  control whether Selectrum should handle in buffer completion (the
+  default is t) ([#261]).
 
 ### Enhancements
 * The argument passed to `selectrum-select-current-candidate` and
@@ -27,8 +30,17 @@ The format is based on [Keep a Changelog].
   first and will also make such prompts behave like in default Emacs
   completion where you can immediately submit the initial input
   ([#253]).
+* In buffer file completions act like normal completion now and insert
+  the candidate without prompting if there is only one. You can drop
+  into the minibuffer by triggering the completion again ([#261]).
+* The mark is pushed at the beginning of the candidate inserted by in
+  buffer completion so you can easily jump there ([#261]).
 
 ### Bugs fixed
+* For in buffer file completions s-expression commands for path level
+  navigation did not work which has been fixed ([#261]).
+* Do not insert spaces after path completion in comint buffers
+  ([#261])].
 * The return value of `selectrum-completion-in-region` has been fixed
   according to the documented API of `completion-in-region` ([#251]).
 * When strings of Selectrum display properties or completion table

--- a/README.md
+++ b/README.md
@@ -295,6 +295,10 @@ matching and case-insensitive matching.
   instead of indices, roman numerals, etc.) you can set the
   `selectrum-show-indices` to a function that takes in the relative
   index of a candidate and returns the string you want to display.
+* By default, Selectrum does also handle in buffer completion via
+  `completion-in-region`. If you would like to disable that you can
+  unset `selectrum-complete-in-buffer` before activating
+  `selectrum-mode`.
 * The `selectrum-completion-in-region` function can display
   annotations if the `completion-in-region-function` backend offers
   them. Customize the face `selectrum-completion-annotation` to change

--- a/selectrum.el
+++ b/selectrum.el
@@ -394,6 +394,11 @@ setting."
 Nil (the default) means to only highlight the displayed text."
   :type 'boolean)
 
+;;;###autoload
+(defcustom selectrum-complete-in-buffer nil
+  "If non-nil, also use Selectrum when completing in non-mini buffers."
+  :type 'boolean)
+
 ;;;; Utility functions
 
 (defun selectrum--clamp (x lower upper)
@@ -1703,13 +1708,15 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
       (prog1 t
         (pcase category
           ('file
-           (setq result
-                 (if (not (cdr cands))
-                     (try-completion input collection predicate)
-                   (selectrum--completing-read-file-name
-                    "Completion: " collection predicate
-                    nil input))
-                 exit-status 'sole))
+           (let ((try (try-completion input collection predicate)))
+             (setq result
+                   (if (and (not (cdr cands))
+                            (stringp try))
+                       try
+                     (selectrum--completing-read-file-name
+                      "Completion: " collection predicate
+                      nil input))
+                   exit-status 'sole)))
           (_
            (setq result
                  (if (not (cdr cands))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1709,10 +1709,11 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
       (prog1 t
         (pcase category
           ('file
-           (let ((try (try-completion input collection predicate)))
+           (let ((try nil))
              (setq result
                    (if (and (not (cdr cands))
-                            (stringp try))
+                            (stringp (setq try (try-completion
+                                                input collection predicate))))
                        try
                      (selectrum--completing-read-file-name
                       "Completion: " collection predicate

--- a/selectrum.el
+++ b/selectrum.el
@@ -395,7 +395,7 @@ Nil (the default) means to only highlight the displayed text."
   :type 'boolean)
 
 ;;;###autoload
-(defcustom selectrum-complete-in-buffer nil
+(defcustom selectrum-complete-in-buffer t
   "If non-nil, also use Selectrum when completing in non-mini buffers."
   :type 'boolean)
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -396,7 +396,8 @@ Nil (the default) means to only highlight the displayed text."
 
 ;;;###autoload
 (defcustom selectrum-complete-in-buffer t
-  "If non-nil, also use Selectrum when completing in non-mini buffers."
+  "If non-nil, also use Selectrum when completing in non-mini buffers.
+This option needs to be set before activating `selectrum-mode'."
   :type 'boolean)
 
 ;;;; Utility functions

--- a/selectrum.el
+++ b/selectrum.el
@@ -2082,8 +2082,9 @@ ARGS are standard as in all `:around' advice."
                         #'selectrum-read-file-name)
           (setq selectrum--old-completion-in-region-function
                 (default-value 'completion-in-region-function))
-          (setq-default completion-in-region-function
-                        #'selectrum-completion-in-region)
+          (when selectrum-complete-in-buffer
+            (setq-default completion-in-region-function
+                          #'selectrum-completion-in-region))
           (advice-add #'completing-read-multiple :override
                       #'selectrum-completing-read-multiple)
           ;; No sharp quote because Dired may not be loaded yet.

--- a/selectrum.el
+++ b/selectrum.el
@@ -396,7 +396,7 @@ Nil (the default) means to only highlight the displayed text."
 
 ;;;###autoload
 (defcustom selectrum-complete-in-buffer t
-  "If non-nil, also use Selectrum when completing in non-mini buffers.
+  "If non-nil, use Selectrum for `completion-in-region'.
 This option needs to be set before activating `selectrum-mode'."
   :type 'boolean)
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -1732,7 +1732,7 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
                  exit-status (cond ((not (member result cands)) 'sole)
                                    (t 'finished)))))
         (delete-region bound end)
-        (push-mark (point) t)
+        (push-mark (point) 'no-message)
         (insert (substring-no-properties result))
         (when exit-func
           (funcall exit-func result exit-status))))))


### PR DESCRIPTION
See #260. This will insert the path immediately if there is only one match and also ensures the syntax table is set correctly for all file completions. I also adjusted the exit-status to `sole` as this leads to the least surprising behaviour (no insertion of spaces after file completion which also does not happen with default completion). The exit status is very much tied to the way default completion works and `sole` seems to make the most sense with selectrum when it is not clearly `finished`. I also decided to push the mark at the start of the candidate so one can easily jump back to the beginning of the completion.