### PR TITLE
Fix error for empty file completions

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -649,7 +649,8 @@ behavior."
   "Get full form of CANDIDATE."
   (or (get-text-property 0 'selectrum-candidate-full candidate)
       (when minibuffer-completing-file-name
-        (if (< selectrum--current-candidate-index 0)
+        (if (and selectrum--current-candidate-index
+                 (< selectrum--current-candidate-index 0))
             candidate
           (let* ((input (minibuffer-contents))
                  (pathprefix (or (file-name-directory input) "")))


### PR DESCRIPTION
Due to recent changes file completions which have initially no candidates would trigger an error on exit.