### PR TITLE
Allow string elements for affixation items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ The format is based on [Keep a Changelog].
   slow already ([#210], [#276], [#277]).
 * If completion table metadata or `completion-extra-properties` define
   an `affixation-function` (introduced in Emacs 28) Selectrum will use
-  this information to annotate the candidates accordingly ([#271],
-  [#240]).
+  this information to annotate the candidates accordingly ([#240],
+  [#271], [#286], [#288]).
 * The argument passed to `selectrum-select-current-candidate` and
   `selectrum-insert-current-candidate` is now used to choose the nth
   displayed candidate instead of calculating an index based on the
@@ -104,6 +104,8 @@ The format is based on [Keep a Changelog].
 [#271]: https://github.com/raxod502/selectrum/pull/271
 [#276]: https://github.com/raxod502/selectrum/issues/276
 [#277]: https://github.com/raxod502/selectrum/pull/277
+[#286]: https://github.com/raxod502/selectrum/issues/286
+[#288]: https://github.com/raxod502/selectrum/pull/288
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1099,11 +1099,13 @@ CAND does not have any face property defined."
         (res ()))
     (dolist (item items (nreverse res))
       (push
-       (propertize (nth 0 item)
-                   'selectrum-candidate-display-prefix
-                   (nth 1 item)
-                   'selectrum-candidate-display-suffix
-                   (nth 2 item))
+       (if (listp item)
+           (propertize (nth 0 item)
+                       'selectrum-candidate-display-prefix
+                       (nth 1 item)
+                       'selectrum-candidate-display-suffix
+                       (nth 2 item))
+         item)
        res))))
 
 (defun selectrum--candidates-display-string (candidates


### PR DESCRIPTION
As reported by #286 there are affixation functions in Emacs 28 which mix list items with strings.
