### PR TITLE
Bind selectrum-active-p locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* `selectrum-active-p` would wrongly report an active status for
+  recursive minibuffer session with Selectrum turned off, which has
+  been fixed ([#293]).
 * File completions are faster because recomputation only happens on
   directory change now. Before, the candidates where recomputed on
   each input change which could slow down file completions

--- a/selectrum.el
+++ b/selectrum.el
@@ -1245,6 +1245,7 @@ TABLE defaults to `minibuffer-completion-table'. PRED defaults to
 CANDIDATES is the list of strings that was passed to
 `selectrum-read'. DEFAULT-CANDIDATE, if provided, is added to the
 list and sorted first."
+  (setq-local selectrum-active-p t)
   (add-hook
    'minibuffer-exit-hook #'selectrum--minibuffer-exit-hook nil 'local)
   (setq-local selectrum--init-p t)
@@ -1523,8 +1524,7 @@ Otherwise, just eval BODY."
               selectrum--visual-input
               selectrum--read-args
               selectrum--count-overlay
-              selectrum--repeat
-              selectrum-active-p)))
+              selectrum--repeat)))
      ;; https://github.com/raxod502/selectrum/issues/39#issuecomment-618350477
      (selectrum--let-maybe
        selectrum-active-p
@@ -1615,7 +1615,6 @@ semantics of `cl-defun'."
              (prompt (selectrum--remove-default-from-prompt prompt))
              ;; <https://github.com/raxod502/selectrum/issues/99>
              (icomplete-mode nil)
-             (selectrum-active-p t)
              (res (read-from-minibuffer
                    prompt initial-input selectrum-minibuffer-map nil
                    (or history 'minibuffer-history))))


### PR DESCRIPTION
`selectrum-active-p` was recursively bound for all sessions which made it report the session state wrongly for recursive session where Selectrum wasn't active. As discussed elswhere at some point we should probably remove `selectrum--save-global-state` all together in favour of local variables.