### PR TITLE
Handle default value symbols like completing-read-default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ The format is based on [Keep a Changelog].
 [#288]: https://github.com/raxod502/selectrum/pull/288
 [#289]: https://github.com/raxod502/selectrum/pull/289
 [#293]: https://github.com/raxod502/selectrum/pull/293
+[#291]: https://github.com/raxod502/selectrum/issues/291
+[#295]: https://github.com/raxod502/selectrum/pull/295
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ The format is based on [Keep a Changelog].
   they contain ([#266]).
 
 ### Bugs fixed
+* Passing a symbol or a list of symbols to `completing-read` as
+  default value DEF would trigger an error, which has been fixed.
+  Selectrum now behaves like `completind-read-default` and returns the
+  symbol (or the first in case of a list) ([#291], [#295]).
 * `selectrum-active-p` would wrongly report an active status for
   recursive minibuffer session with Selectrum turned off, which has
   been fixed ([#293]).

--- a/selectrum.el
+++ b/selectrum.el
@@ -1268,7 +1268,10 @@ list and sorted first."
                (funcall selectrum-preprocess-candidates-function
                         candidates))
          (setq selectrum--total-num-candidates (length candidates))))
-  (setq selectrum--default-candidate default-candidate)
+  (setq selectrum--default-candidate
+        (if (and default-candidate (symbolp default-candidate))
+            (symbol-name default-candidate)
+          default-candidate))
   ;; Make sure to trigger an "user input changed" event, so that
   ;; candidate refinement happens in `post-command-hook' and an index
   ;; is assigned.
@@ -1619,13 +1622,14 @@ semantics of `cl-defun'."
                    prompt initial-input selectrum-minibuffer-map nil
                    (or history 'minibuffer-history))))
         (cond (minibuffer-completion-table
-               ;; Behave like completing-read-default which strips the text
-               ;; properties but keeps them when submitting the empty prompt
-               ;; to get the default (see #180, #107).
+               ;; Behave like completing-read-default which strips the
+               ;; text properties but leaves the default unchanged
+               ;; when submitting the empty prompt to get it (see
+               ;; #180, #107).
                (if (and selectrum--previous-input-string
                         (string-empty-p selectrum--previous-input-string)
                         (equal res selectrum--default-candidate))
-                   selectrum--default-candidate
+                   default-candidate
                  (substring-no-properties res)))
               (t res))))))
 


### PR DESCRIPTION
As reported in #291 