### PR TITLE
Improve completing-read-multiple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* Candidates of `completing-read-multiple` which are submitted by
+  `selectrum-select-current-candidate` are now passed to
+  `selectrum-candidate-selected-hook` one by one in the order they
+  were added. Before the hook would not run for the multi candidates
+  case ([#296]).
 * File completions are faster because recomputation only happens on
   directory change now. Before, the candidates where recomputed on
   each input change which could slow down file completions
@@ -54,6 +59,15 @@ The format is based on [Keep a Changelog].
   they contain ([#266]).
 
 ### Bugs fixed
+* `selectrum-insert-current-candidate` would duplicate the prompt for
+  `completing-read-multiple` when the prompt was selected, which has
+  been fixed. The behavior is now like in `completing-read` ([#296]).
+* `selectrum-select-current-candidate` did not work correctly for
+  `completing-read-multiple` when the prompt was submitted, which has
+  been fixed ([#285], [#296]).
+* `selectrum-candidate-inserted-hook` would run after using
+  `selectrum-insert-current-candidate` with a selected prompt, which
+  has been fixed ([#296]).
 * Passing a symbol or a list of symbols to `completing-read` as
   default value DEF would trigger an error, which has been fixed.
   Selectrum now behaves like `completind-read-default` and returns the
@@ -111,12 +125,14 @@ The format is based on [Keep a Changelog].
 [#271]: https://github.com/raxod502/selectrum/pull/271
 [#276]: https://github.com/raxod502/selectrum/issues/276
 [#277]: https://github.com/raxod502/selectrum/pull/277
+[#285]: https://github.com/raxod502/selectrum/issues/285
 [#286]: https://github.com/raxod502/selectrum/issues/286
 [#288]: https://github.com/raxod502/selectrum/pull/288
 [#289]: https://github.com/raxod502/selectrum/pull/289
 [#293]: https://github.com/raxod502/selectrum/pull/293
 [#291]: https://github.com/raxod502/selectrum/issues/291
 [#295]: https://github.com/raxod502/selectrum/pull/295
+[#296]: https://github.com/raxod502/selectrum/pull/296
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1477,8 +1477,8 @@ indices."
              #'run-hook-with-args
              'selectrum-candidate-inserted-hook
              full selectrum--read-args))
-          ;;  Ensure refresh of UI. The input input string might be
-          ;; the same when the prompt was selected, this will switch
+          ;; Ensure refresh of UI. The input input string might be the
+          ;; same when the prompt was selected, this will switch
           ;; selection to first candidate in that case.
           (setq selectrum--previous-input-string nil))
       (unless completion-fail-discreetly

--- a/selectrum.el
+++ b/selectrum.el
@@ -1362,7 +1362,8 @@ plus CANDIDATE."
                                  (with-temp-buffer
                                    (insert selectrum--previous-input-string)
                                    (goto-char (point-min))
-                                   (while (re-search-forward crm-separator nil t))
+                                   (while (re-search-forward
+                                           crm-separator nil t))
                                    (delete-region (point) (point-max))
                                    (insert (selectrum--get-full candidate))
                                    (buffer-string)))))
@@ -1469,7 +1470,8 @@ indices."
                    (delete-region (point) (point-max))
                    (insert full)
                    (when-let ((match
-                               (assoc crm-separator selectrum--crm-separator-alist)))
+                               (assoc crm-separator
+                                      selectrum--crm-separator-alist)))
                      (insert (cdr match)))))
             (apply
              #'run-hook-with-args

--- a/selectrum.el
+++ b/selectrum.el
@@ -1358,7 +1358,8 @@ plus CANDIDATE."
                                            selectrum--previous-input-string))
                         (let ((crm
                                (if (and selectrum--current-candidate-index
-                                        (< selectrum--current-candidate-index 0))
+                                        (< selectrum--current-candidate-index
+                                           0))
                                    candidate
                                  (with-temp-buffer
                                    (insert selectrum--previous-input-string)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1357,7 +1357,8 @@ plus CANDIDATE."
                              (string-match crm-separator
                                            selectrum--previous-input-string))
                         (let ((crm
-                               (if (< selectrum--current-candidate-index 0)
+                               (if (and selectrum--current-candidate-index
+                                        (< selectrum--current-candidate-index 0))
                                    candidate
                                  (with-temp-buffer
                                    (insert selectrum--previous-input-string)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1349,13 +1349,23 @@ plus CANDIDATE."
   (let* ((result (cond ((and selectrum--crm-p
                              (string-match crm-separator
                                            selectrum--previous-input-string))
-                        (with-temp-buffer
-                          (insert selectrum--previous-input-string)
-                          (goto-char (point-min))
-                          (while (re-search-forward crm-separator nil t))
-                          (delete-region (point) (point-max))
-                          (insert (selectrum--get-full candidate))
-                          (buffer-string)))
+                        (let ((crm
+                               (if (< selectrum--current-candidate-index 0)
+                                   candidate
+                                 (with-temp-buffer
+                                   (insert selectrum--previous-input-string)
+                                   (goto-char (point-min))
+                                   (while (re-search-forward crm-separator nil t))
+                                   (delete-region (point) (point-max))
+                                   (insert (selectrum--get-full candidate))
+                                   (buffer-string)))))
+                          (dolist (cand (split-string crm crm-separator t))
+                            (apply
+                             #'run-hook-with-args
+                             'selectrum-candidate-selected-hook
+                             candidate selectrum--read-args)
+                            (selectrum--get-full cand))
+                          crm))
                        (t
                         (apply
                          #'run-hook-with-args
@@ -1436,30 +1446,31 @@ indices."
              (candidate (selectrum--get-candidate index))
              (full (selectrum--get-full candidate)))
         (progn
-          (if (not selectrum--crm-p)
-              (progn
-                (delete-region (minibuffer-prompt-end)
-                               (point-max))
-                (insert full))
-            (goto-char
-             (if (re-search-backward crm-separator
-                                     (minibuffer-prompt-end) t)
-                 (match-end 0)
-
-               (minibuffer-prompt-end)))
-            (delete-region (point) (point-max))
-            (insert full)
-            (when-let ((match
-                        (assoc crm-separator selectrum--crm-separator-alist)))
-              (insert (cdr match))))
-          (apply
-           #'run-hook-with-args
-           'selectrum-candidate-inserted-hook
-           candidate selectrum--read-args)
+          ;; Ignore for prompt selection.
+          (unless (and selectrum--current-candidate-index
+                       (< selectrum--current-candidate-index 0))
+            (cond ((not selectrum--crm-p)
+                   (delete-region (minibuffer-prompt-end)
+                                  (point-max))
+                   (insert full))
+                  (t
+                   (goto-char
+                    (if (re-search-backward crm-separator
+                                            (minibuffer-prompt-end) t)
+                        (match-end 0)
+                      (minibuffer-prompt-end)))
+                   (delete-region (point) (point-max))
+                   (insert full)
+                   (when-let ((match
+                               (assoc crm-separator selectrum--crm-separator-alist)))
+                     (insert (cdr match)))))
+            (apply
+             #'run-hook-with-args
+             'selectrum-candidate-inserted-hook
+             full selectrum--read-args))
           ;;  Ensure refresh of UI. The input input string might be
-          ;; the same when the prompt was reinserted. When the prompt
-          ;; was selected this will switch selection to first
-          ;; candidate.
+          ;; the same when the prompt was selected, this will switch
+          ;; selection to first candidate in that case.
           (setq selectrum--previous-input-string nil))
       (unless completion-fail-discreetly
         (ding)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1373,8 +1373,8 @@ plus CANDIDATE."
                             (apply
                              #'run-hook-with-args
                              'selectrum-candidate-selected-hook
-                             candidate selectrum--read-args)
-                            (selectrum--get-full cand))
+                             (selectrum--get-full cand)
+                             selectrum--read-args))
                           crm))
                        (t
                         (apply


### PR DESCRIPTION
This will address the problems with completing-read-multiple when submitting the prompt, see #285. Additionally I took care of submitting each individual candidate to `selectrum-candidate-selected-hook` and fixed `selectrum-insert-current-candidate` which didn't work correctly with completing-read-multiple when the prompt was selected.