### PR TITLE
Add keep-selection arg to selectrum-exhibit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### Features
+* `selectrum-exhibit` got an optional argument which allows to keep
+  the current candidate selected after the update which is helpful for
+  async completions ([#306], [#307]).
 * The user option `selectrum-display-action` can be used to show
   candidates in another window or frame ([#230], [#309]).
 * The user option `selectrum-show-indices` can now be a function that
@@ -140,6 +143,8 @@ The format is based on [Keep a Changelog].
 [#295]: https://github.com/raxod502/selectrum/pull/295
 [#296]: https://github.com/raxod502/selectrum/pull/296
 [#302]: https://github.com/raxod502/selectrum/pull/302
+[#306]: https://github.com/raxod502/selectrum/issues/306
+[#307]: https://github.com/raxod502/selectrum/pull/307
 [#309]: https://github.com/raxod502/selectrum/pull/309
 [#312]: https://github.com/raxod502/selectrum/issues/312
 [#316]: https://github.com/raxod502/selectrum/pull/316

--- a/selectrum.el
+++ b/selectrum.el
@@ -554,11 +554,6 @@ updates is skipped.")
 This is non-nil during the first call of
 `selectrum--minibuffer-post-command-hook'.")
 
-(defvar selectrum--keep-candidate nil
-  "Whether to keep the current candidate selected.
-When the candidate is still a member of the refined results this
-will keep it selected after updates.")
-
 (defvar selectrum--total-num-candidates nil
   "Saved number of candidates, used for `selectrum-show-indices'.")
 
@@ -656,11 +651,9 @@ when possible."
                  (not selectrum--dynamic-candidates))
         (setq selectrum--preprocessed-candidates nil))
       (setq selectrum--previous-input-string nil)
-      (let ((selectrum--keep-candidate
-             (if keep-selection
-                 (selectrum-get-current-candidate)
-               selectrum--keep-candidate)))
-        (selectrum--minibuffer-post-command-hook)))))
+      (selectrum--minibuffer-update
+       (and keep-selection
+            (selectrum-get-current-candidate))))))
 
 ;;;; Hook functions
 
@@ -710,6 +703,12 @@ greather than the window height."
 
 (defun selectrum--minibuffer-post-command-hook ()
   "Update minibuffer in response to user input."
+  (selectrum--minibuffer-update))
+
+(defun selectrum--minibuffer-update (&optional keep-selected)
+  "Update minibuffer state.
+KEEP-SELECTED can be a candidate which should stay selected after
+the update."
   (unless selectrum--skip-updates-p
     ;; Stay within input area.
     (goto-char (max (point) (minibuffer-prompt-end)))
@@ -789,8 +788,8 @@ greather than the window height."
               (setq selectrum--repeat nil))
           (setq selectrum--current-candidate-index
                 (cond
-                 ((and selectrum--keep-candidate
-                       (cl-position selectrum--keep-candidate
+                 ((and keep-selected
+                       (cl-position keep-selected
                                     selectrum--refined-candidates
                                     :key #'selectrum--get-full
                                     :test #'equal)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -653,7 +653,7 @@ INPUT defaults to current selectrum input string."
 (defun selectrum-exhibit (&optional keep-selection)
   "Trigger an update of Selectrum's completion UI.
 If KEEP-SELECTION is non-nil keep the current candidate selected
-when possible."
+when possible (it is still a member of the candidate set)."
   (when-let ((mini (active-minibuffer-window)))
     (with-selected-window mini
       (when (and minibuffer-completion-table

--- a/selectrum.el
+++ b/selectrum.el
@@ -783,30 +783,30 @@ greather than the window height."
                               (1- (length selectrum--refined-candidates)))))
               (setq selectrum--repeat nil))
           (setq selectrum--current-candidate-index
-                  (cond
-                   (selectrum--keep-index
-                    (min (1- selectrum--total-num-candidates)
-                         selectrum--current-candidate-index))
-                   ((null selectrum--refined-candidates)
-                    (when (not selectrum--match-required-p)
-                      -1))
-                   ((and selectrum--default-candidate
-                         (string-empty-p (minibuffer-contents))
-                         (not (member selectrum--default-candidate
-                                      selectrum--refined-candidates)))
-                    -1)
-                   ((and selectrum--init-p
-                         (equal selectrum--default-candidate
-                                (minibuffer-contents)))
-                    -1)
-                   (selectrum--move-default-candidate-p
-                    0)
-                   (t
-                    (or (cl-position selectrum--default-candidate
-                                     selectrum--refined-candidates
-                                     :key #'selectrum--get-full
-                                     :test #'equal)
-                        0))))))
+                (cond
+                 (selectrum--keep-index
+                  (min (1- selectrum--total-num-candidates)
+                       selectrum--current-candidate-index))
+                 ((null selectrum--refined-candidates)
+                  (when (not selectrum--match-required-p)
+                    -1))
+                 ((and selectrum--default-candidate
+                       (string-empty-p (minibuffer-contents))
+                       (not (member selectrum--default-candidate
+                                    selectrum--refined-candidates)))
+                  -1)
+                 ((and selectrum--init-p
+                       (equal selectrum--default-candidate
+                              (minibuffer-contents)))
+                  -1)
+                 (selectrum--move-default-candidate-p
+                  0)
+                 (t
+                  (or (cl-position selectrum--default-candidate
+                                   selectrum--refined-candidates
+                                   :key #'selectrum--get-full
+                                   :test #'equal)
+                      0))))))
       (overlay-put selectrum--count-overlay
                    'before-string (selectrum--count-info))
       (overlay-put selectrum--count-overlay

--- a/selectrum.el
+++ b/selectrum.el
@@ -660,7 +660,7 @@ when possible."
                  (not selectrum--dynamic-candidates))
         (setq selectrum--preprocessed-candidates nil))
       (setq selectrum--previous-input-string nil)
-      (selectrum--minibuffer-update
+      (selectrum--update
        (and keep-selection
             (selectrum-get-current-candidate))))))
 
@@ -711,10 +711,10 @@ greather than the window height."
 
 (defun selectrum--minibuffer-post-command-hook ()
   "Update minibuffer in response to user input."
-  (selectrum--minibuffer-update))
+  (selectrum--update))
 
-(defun selectrum--minibuffer-update (&optional keep-selected)
-  "Update minibuffer state.
+(defun selectrum--update (&optional keep-selected)
+  "Update state.
 KEEP-SELECTED can be a candidate which should stay selected after
 the update."
   (unless selectrum--skip-updates-p
@@ -796,11 +796,12 @@ the update."
               (setq selectrum--repeat nil))
           (setq selectrum--current-candidate-index
                 (cond
-                 ((and keep-selected
-                       (cl-position keep-selected
-                                    selectrum--refined-candidates
-                                    :key #'selectrum--get-full
-                                    :test #'equal)))
+                 (keep-selected
+                  (or (cl-position keep-selected
+                                   selectrum--refined-candidates
+                                   :key #'selectrum--get-full
+                                   :test #'equal)
+                      0))
                  ((null selectrum--refined-candidates)
                   (when (not selectrum--match-required-p)
                     -1))

--- a/selectrum.el
+++ b/selectrum.el
@@ -782,9 +782,11 @@ greather than the window height."
                          (min (or selectrum--current-candidate-index 0)
                               (1- (length selectrum--refined-candidates)))))
               (setq selectrum--repeat nil))
-          (unless selectrum--keep-index
-            (setq selectrum--current-candidate-index
+          (setq selectrum--current-candidate-index
                   (cond
+                   (selectrum--keep-index
+                    (min (1- selectrum--total-num-candidates)
+                         selectrum--current-candidate-index))
                    ((null selectrum--refined-candidates)
                     (when (not selectrum--match-required-p)
                       -1))
@@ -804,7 +806,7 @@ greather than the window height."
                                      selectrum--refined-candidates
                                      :key #'selectrum--get-full
                                      :test #'equal)
-                        0)))))))
+                        0))))))
       (overlay-put selectrum--count-overlay
                    'before-string (selectrum--count-info))
       (overlay-put selectrum--count-overlay


### PR DESCRIPTION
@minad As we discussed this lets you call `selectrum-exhibit` without updating the index which is allows for better handling of async completions as shown in #306. 
