### PR TITLE
Allow locally set display actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 ## Unreleased
 ### Features
 * The user option `selectrum-display-action` can be used to show
-  candidates in another window or frame ([#230]).
+  candidates in another window or frame ([#230], [#309]).
 * The user option `selectrum-show-indices` can now be a function that
   can be used to control the display of the a candidate's index ([#200]).
 * The user option `selectrum-extend-current-candidate-highlight`
@@ -137,6 +137,7 @@ The format is based on [Keep a Changelog].
 [#295]: https://github.com/raxod502/selectrum/pull/295
 [#296]: https://github.com/raxod502/selectrum/pull/296
 [#302]: https://github.com/raxod502/selectrum/pull/302
+[#309]: https://github.com/raxod502/selectrum/pull/309
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -677,13 +677,12 @@ Window will be created by `selectrum-display-action'."
                    (setq buffer-read-only t)
                    (setq show-trailing-whitespace nil)
                    (goto-char (point-min))
-                   (current-buffer)))))
+                   (current-buffer))))
+        (action selectrum-display-action))
     (or (get-buffer-window buf 'visible)
         (with-selected-window (minibuffer-selected-window)
           (let* ((frame (selected-frame))
-                 (window (display-buffer
-                          buf
-                          selectrum-display-action)))
+                 (window (display-buffer buf action)))
             (select-frame-set-input-focus frame)
             window)))))
 


### PR DESCRIPTION
The display action will be called from the window that selected the minibuffer but should use the value bound in the minibuffer for the case the caller has bound it locally for the current session.