### PR TITLE
Compute table candidates with last buffer current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* Computation of candidates is faster for cases where the table
+  predicate makes the last buffer current, most notably this speeds up
+  the `describe-variable` command ([#312], [#316]).
 * Candidates of `completing-read-multiple` which are submitted by
   `selectrum-select-current-candidate` are now passed to
   `selectrum-candidate-selected-hook` one by one in the order they
@@ -138,6 +141,8 @@ The format is based on [Keep a Changelog].
 [#296]: https://github.com/raxod502/selectrum/pull/296
 [#302]: https://github.com/raxod502/selectrum/pull/302
 [#309]: https://github.com/raxod502/selectrum/pull/309
+[#312]: https://github.com/raxod502/selectrum/issues/312
+[#316]: https://github.com/raxod502/selectrum/pull/316
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -443,8 +443,12 @@ damaging the original COLLECTION.
 
 If PREDICATE is non-nil, then it filters the collection as in
 `all-completions'."
-  (let ((completion-regexp-list nil))
-    (all-completions "" collection predicate)))
+  ;; Making the last buffer current avoids the cost of potential
+  ;; buffer switching for each candidate within the predicate (see
+  ;; `describe-variable').
+  (with-current-buffer (window-buffer (minibuffer-selected-window))
+    (let ((completion-regexp-list nil))
+      (all-completions "" collection predicate))))
 
 (defun selectrum--remove-default-from-prompt (prompt)
   "Remove the indication of the default value from PROMPT.

--- a/selectrum.el
+++ b/selectrum.el
@@ -434,7 +434,7 @@ destructively and return the modified list."
         (setq link (cdr link))))
     (nconc (nreverse elts) (cdr lst))))
 
-(defun selectrum--normalize-collection (collection &optional predicate)
+(defun selectrum--normalize-collection (collection &optional predicate buffer)
   "Normalize COLLECTION into a list of strings.
 COLLECTION may be a list of strings or symbols or cons cells, an
 obarray, a hash table, or a function, as per the docstring of
@@ -442,11 +442,16 @@ obarray, a hash table, or a function, as per the docstring of
 damaging the original COLLECTION.
 
 If PREDICATE is non-nil, then it filters the collection as in
-`all-completions'."
+`all-completions'.
+
+BUFFER is the buffer to compute the candidates in. It defaults to
+buffer of the selected window except for minibuffers where it
+defaults to the buffer of `minibuffer-selected-window'."
   ;; Making the last buffer current avoids the cost of potential
   ;; buffer switching for each candidate within the predicate (see
   ;; `describe-variable').
-  (with-current-buffer (window-buffer (minibuffer-selected-window))
+  (with-current-buffer (or buffer
+                           (window-buffer (minibuffer-selected-window)))
     (let ((completion-regexp-list nil))
       (all-completions "" collection predicate))))
 


### PR DESCRIPTION
As discussed in #75 and #312 `describe-variable` was slowed down with Selectrum because the predicate switches back to the last buffer for each candidate. By computing the candidates with the last buffer current by default we avoid the slow down for such cases. The docs don't mention any assumptions about the current buffer for the table/predicate, Ivy does run the computation before the minibuffer is even entered so it doesn't has this problem, we keep computing them late to allow for example `selectrum-set-selected-candidate` to skip the initial computation which is used by `embark` for example.
