### PR TITLE
Show multiline annotations for empty input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ The format is based on [Keep a Changelog].
   prompt was reinserted in place so it did not have any useful effect
   ([#263]).
 * Multiline candidates are now prefixed with the number of newlines
-  they contain ([#266], [#302]).
+  they contain ([#266], [#302], [#318]).
 
 ### Bugs fixed
 * `selectrum-extend-current-candidate-highlight`,
@@ -153,6 +153,7 @@ The format is based on [Keep a Changelog].
 [#312]: https://github.com/raxod502/selectrum/issues/312
 [#316]: https://github.com/raxod502/selectrum/pull/316
 [#317]: https://github.com/raxod502/selectrum/pull/317
+[#318]: https://github.com/raxod502/selectrum/pull/318
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -998,7 +998,8 @@ SETTINGS, see `selectrum-multiline-display-settings'."
       (if (string-match-p "\n" cand)
           (let* ((lines (split-string cand "\n"))
                  (len (length lines))
-                 (fmatch (if (string-empty-p (minibuffer-contents))
+                 (input (minibuffer-contents))
+                 (fmatch (if (string-empty-p input)
                              (with-temp-buffer
                                (insert cand)
                                (goto-char (point-min))
@@ -1007,7 +1008,7 @@ SETTINGS, see `selectrum-multiline-display-settings'."
                                                  (line-end-position)))
                            (car (funcall
                                  selectrum-refine-candidates-function
-                                 (minibuffer-contents)
+                                 input
                                  lines))))
                  (match
                   (propertize

--- a/selectrum.el
+++ b/selectrum.el
@@ -998,19 +998,23 @@ The specific details of the formatting are determined by
       (if (string-match-p "\n" cand)
           (let* ((lines (split-string cand "\n"))
                  (len (length lines))
-                 (fmatch (car (funcall
-                               selectrum-refine-candidates-function
-                               (minibuffer-contents)
-                               lines)))
+                 (fmatch (if (string-empty-p (minibuffer-contents))
+                             (with-temp-buffer
+                               (insert cand)
+                               (goto-char (point-min))
+                               (skip-chars-forward " \t\n")
+                               (buffer-substring (line-beginning-position)
+                                                 (line-end-position)))
+                           (car (funcall
+                                 selectrum-refine-candidates-function
+                                 (minibuffer-contents)
+                                 lines))))
                  (match
                   (propertize
                    (replace-regexp-in-string
                     "[ \t][ \t]+"
                     (propertize whitespace/display 'face whitespace/face)
-                    (if (string-empty-p (minibuffer-contents))
-                        ""
-                      ;; Show first matched line.
-                      (or fmatch "")) 'fixed-case 'literal)
+                    (or fmatch "") 'fixed-case 'literal)
                    'selectrum-candidate-display-prefix
                    (propertize (format "(%d lines)" len)
                                'face newline/face)))


### PR DESCRIPTION
This improves multiline display again by also showing the annotations when there is no input
