### PR TITLE
Pass candidate as it appears in collection to selectrum-candidate-inserted-hook

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -1505,7 +1505,7 @@ indices."
             (apply
              #'run-hook-with-args
              'selectrum-candidate-inserted-hook
-             full selectrum--read-args))
+             candidate selectrum--read-args))
           ;; Ensure refresh of UI. The input input string might be the
           ;; same when the prompt was reinserted. When the prompt was
           ;; selected this will switch selection to first candidate.


### PR DESCRIPTION
The candidates should be saved with the same value they have in the collection.