### PR TITLE
Improve selectrum-completion-in-region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ The format is based on [Keep a Changelog].
   they contain ([#266], [#302], [#318]).
 
 ### Bugs fixed
+* `selectrum-completion-in-region` could trigger an error when
+  `completion-all-completions` would be called within a session, which
+  has been fixed ([#315], [#329]).
 * `selectrum-select-from-history` wasn't autoloaded which would
   trigger an error when used before Selectrum was loaded, this has
   been fixed ([#310], [#328]).
@@ -162,6 +165,7 @@ The format is based on [Keep a Changelog].
 [#309]: https://github.com/raxod502/selectrum/pull/309
 [#310]: https://github.com/raxod502/selectrum/issues/310
 [#312]: https://github.com/raxod502/selectrum/issues/312
+[#315]: https://github.com/raxod502/selectrum/issues/315
 [#316]: https://github.com/raxod502/selectrum/pull/316
 [#317]: https://github.com/raxod502/selectrum/pull/317
 [#318]: https://github.com/raxod502/selectrum/pull/318
@@ -171,6 +175,7 @@ The format is based on [Keep a Changelog].
 [#324]: https://github.com/raxod502/selectrum/pull/324
 [#327]: https://github.com/raxod502/selectrum/pull/327
 [#328]: https://github.com/raxod502/selectrum/pull/328
+[#329]: https://github.com/raxod502/selectrum/pull/329
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1821,12 +1821,10 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
            (setq result
                  (if (not (cdr cands))
                      (car cands)
-                   (selectrum-completing-read
-                    "Completion: "
-                    (lambda (string pred action)
-                      (if (eq action 'metadata)
-                          meta
-                        (complete-with-action action cands string pred)))))
+                   (selectrum-read
+                    "Completion: " cands
+                    :minibuffer-completion-table collection
+                    :minibuffer-completion-predicate predicate))
                  exit-status (cond ((not (member result cands)) 'sole)
                                    (t 'finished)))))
         (delete-region bound end)


### PR DESCRIPTION
Passing another table with the same metadata to `selectrum-completing-read` could trigger errors, see #315. By using `selectrum-read` directly and pass minibuffer-completion-table and predicate there is still access to the metadata and it avoids this problem.