### PR TITLE
Add selectrum-completion-in-region-styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* You can now configure `completion-styles` for the initial filtering
+  of `selectrum-completion-in-region` using
+  `selectrum-completion-in-region-styles` ([#331]).
 * The prompt gets selected when using `next-history-element` and the
   prompt equals the default ([#323], [#324]).
 * Computation of candidates is faster for `describe-variable` ([#312],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,7 @@ The format is based on [Keep a Changelog].
 [#327]: https://github.com/raxod502/selectrum/pull/327
 [#328]: https://github.com/raxod502/selectrum/pull/328
 [#329]: https://github.com/raxod502/selectrum/pull/329
+[#331]: https://github.com/raxod502/selectrum/pull/331
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ matching and case-insensitive matching.
     * Customize the face `completions-common-part` to change the
       appearance of the common prefix in `completion-in-region`
       candidates.
+* You can configure `completion-styles` for the initial filtering of
+  `selectrum-completion-in-region` using
+  `selectrum-completion-in-region-styles`.
 
 As an example of customizing the faces, I use the
 [Zerodark](https://github.com/NicolasPetton/zerodark-theme) color

--- a/selectrum.el
+++ b/selectrum.el
@@ -185,6 +185,15 @@ list of strings."
                        (string-lessp c1 c2)))))
     candidates))
 
+(defcustom selectrum-completion-in-region-styles
+  '(basic partial-completion emacs22)
+  "The `completion-styles' used by `selectrum-completion-in-region'.
+These are used for the initial filtering of candidates according
+to the text around point. The initial filtering styles for
+completion in region might generally differ from the styles you
+want to use for usual completion."
+  :type 'completion--styles-type)
+
 (defcustom selectrum-preprocess-candidates-function
   #'selectrum-default-candidate-preprocess-function
   "Function used to preprocess the list of candidates.
@@ -1786,16 +1795,11 @@ COLLECTION, and PREDICATE, see `completion-in-region'."
          (exit-func (plist-get completion-extra-properties
                                :exit-function))
          (cands (nconc
-                 ;; `completion-styles' is used for the initial
-                 ;; filtering here internally! Selectrum doesn't use
-                 ;; `completion-styles' in other places yet. For
-                 ;; completion in region this matches the expected
-                 ;; behavior because the candidates should be
-                 ;; determined according to the sourrounding text
-                 ;; that gets completed for which
-                 ;; `completion-styles' is typically configured.
-                 (completion-all-completions input collection predicate
-                                             (- end start) meta)
+                 (let ((completion-styles
+                        selectrum-completion-in-region-styles))
+                   (completion-all-completions
+                    input collection predicate
+                    (- end start) meta))
                  nil))
          ;; See doc of `completion-extra-properties'.
          (exit-status nil)


### PR DESCRIPTION
The initial filtering styles for completion in region might generally differ from the styles you
want to use for usual completion and this option lets you configure that.