### PR TITLE
Improve exit when match required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ The format is based on [Keep a Changelog].
 [#331]: https://github.com/raxod502/selectrum/pull/331
 [#334]: https://github.com/raxod502/selectrum/issues/334
 [#335]: https://github.com/raxod502/selectrum/pull/335
+[#338]: https://github.com/raxod502/selectrum/pull/338
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* Improved exit behaviour of `selectrum-select-current-candidate`. The
+  commands gives feedback now when match is required and submission
+  not possible. Also it allows submission of the prompt when a match
+  is required but it is a member of candidates ([#338]).
 * You can now configure `completion-styles` for the initial filtering
   of `selectrum-completion-in-region` using
   `selectrum-completion-in-region-styles` ([#331]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog].
 * Improved exit behaviour of `selectrum-select-current-candidate`. The
   commands gives feedback now when match is required and submission
   not possible. Also it allows submission of the prompt when a match
-  is required but it is a member of candidates ([#338]).
+  is required and the prompt is a member of candidates ([#338]).
 * You can now configure `completion-styles` for the initial filtering
   of `selectrum-completion-in-region` using
   `selectrum-completion-in-region-styles` ([#331]).

--- a/selectrum.el
+++ b/selectrum.el
@@ -1457,16 +1457,20 @@ indices."
     (user-error "Cannot select a candidate when Selectrum is not active"))
   (with-selected-window (active-minibuffer-window)
     (let ((index (selectrum--index-for-arg arg)))
-      (when (or (not selectrum--match-required-p)
-                (and index (>= index 0))
-                (and minibuffer-completing-file-name
-                     (file-exists-p
-                      (substitute-in-file-name
-                       (minibuffer-contents))))
-                (string-empty-p
-                 (minibuffer-contents)))
-        (selectrum--exit-with
-         (selectrum--get-candidate index))))))
+      (if (or (not selectrum--match-required-p)
+              (string-empty-p
+               (minibuffer-contents))
+              (and index (>= index 0))
+              (if minibuffer-completing-file-name
+                  (file-exists-p
+                   (substitute-in-file-name
+                    (minibuffer-contents)))
+                (member (minibuffer-contents)
+                        selectrum--refined-candidates)))
+          (selectrum--exit-with
+           (selectrum--get-candidate index))
+        (minibuffer-message
+         (propertize "Match required" 'face 'minibuffer-prompt))))))
 
 (defun selectrum-submit-exact-input ()
   "Exit minibuffer, using the current user input.


### PR DESCRIPTION
Allow submitting selected prompt when it is a member of candidates and give feedback that match is required and submission not possible. This allowed submission in this case make sense and is also needed for #341 which will select the prompt for history commands.
