### PR TITLE
Select prompt for history commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* With commands `next-history-element` and `previous-history-element`
+  the inserted history element will get selected which helps when the
+  element isn't a member of the candidate set and fixes a problem with
+  file completions when the element is a directory. Before the first
+  file in that directory would be selected ([#323], [#324], [#341]).
 * Improved exit behaviour of `selectrum-select-current-candidate`. The
   commands gives feedback now when match is required and submission
   not possible. Also it allows submission of the prompt when a match
@@ -27,8 +32,6 @@ The format is based on [Keep a Changelog].
 * You can now configure `completion-styles` for the initial filtering
   of `selectrum-completion-in-region` using
   `selectrum-completion-in-region-styles` ([#331]).
-* The prompt gets selected when using `next-history-element` and the
-  prompt equals the default ([#323], [#324]).
 * Computation of candidates is faster for `describe-variable` ([#312],
   [#316], [#320], [#321]).
 * Candidates of `completing-read-multiple` which are submitted by
@@ -196,6 +199,7 @@ The format is based on [Keep a Changelog].
 [#337]: https://github.com/raxod502/selectrum/pull/337
 [#338]: https://github.com/raxod502/selectrum/pull/338
 [#339]: https://github.com/raxod502/selectrum/pull/339
+[#341]: https://github.com/raxod502/selectrum/pull/341
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -816,10 +816,11 @@ the update."
                        (not (member selectrum--default-candidate
                                     selectrum--refined-candidates)))
                   -1)
-                 ((and (or selectrum--init-p
-                           (eq this-command 'next-history-element))
-                       (equal selectrum--default-candidate
-                              (minibuffer-contents)))
+                 ((or (and selectrum--init-p
+                           (equal selectrum--default-candidate
+                                  (minibuffer-contents)))
+                      (memq this-command '(next-history-element
+                                           previous-history-element)))
                   -1)
                  (selectrum--move-default-candidate-p
                   0)

--- a/selectrum.el
+++ b/selectrum.el
@@ -819,8 +819,9 @@ the update."
                  ((or (and selectrum--init-p
                            (equal selectrum--default-candidate
                                   (minibuffer-contents)))
-                      (memq this-command '(next-history-element
-                                           previous-history-element)))
+                      (and (not (= (minibuffer-prompt-end) (point-max)))
+                           (memq this-command '(next-history-element
+                                                previous-history-element))))
                   -1)
                  (selectrum--move-default-candidate-p
                   0)


### PR DESCRIPTION
When browsing the history it makes sense to select the prompt because the history candidate might not be a member for the candidate set and also for file completions a history entry that is a directory would select the first file and not the history item.