### PR TITLE
Change let bound minibuffer setting bindings in selectrum-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,8 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
-* Minibuffer settings `minibuffer-allow-text-properties`,
-  `resize-mini-windows` and `max-mini-window-height` are now locally
-  set for the current session and icomplete-mode is also only
-  deactivated per session so recursive sessions are unaffected
-  ([#342]).
+* `icomplete-mode` is now only disabled for the current session so
+  recursive sessions are unaffected ([#342]).
 * With commands `next-history-element` and `previous-history-element`
   the inserted history element will get selected which helps when the
   element isn't a member of the candidate set and fixes a problem with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* Minibuffer settings `minibuffer-allow-text-properties`,
+  `resize-mini-windows` and `max-mini-window-height` are now locally
+  set for the current session and icomplete-mode is also only
+  deactivated per session so recursive sessions are unaffected
+  ([#342]).
 * With commands `next-history-element` and `previous-history-element`
   the inserted history element will get selected which helps when the
   element isn't a member of the candidate set and fixes a problem with
@@ -200,6 +205,7 @@ The format is based on [Keep a Changelog].
 [#338]: https://github.com/raxod502/selectrum/pull/338
 [#339]: https://github.com/raxod502/selectrum/pull/339
 [#341]: https://github.com/raxod502/selectrum/pull/341
+[#342]: https://github.com/raxod502/selectrum/pull/342
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1288,9 +1288,6 @@ CANDIDATES is the list of strings that was passed to
 list and sorted first. If `minibuffer-default' is set it will
 have precedence over DEFAULT-CANDIDATE."
   (setq-local selectrum-active-p t)
-  (setq-local resize-mini-windows 'grow-only)
-  (setq-local max-mini-window-height
-              (1+ selectrum-num-candidates-displayed))
   (add-hook
    'minibuffer-exit-hook #'selectrum--minibuffer-exit-hook nil 'local)
   (setq-local selectrum--init-p t)
@@ -1684,6 +1681,7 @@ semantics of `cl-defun'."
     (setq selectrum--match-required-p require-match)
     (setq selectrum--move-default-candidate-p (not no-move-default-candidate))
     (let* ((prompt (selectrum--remove-default-from-prompt prompt))
+           ;; Needs to be let bound to have an effect.
            (minibuffer-allow-text-properties t)
            (res
             (minibuffer-with-setup-hook

--- a/selectrum.el
+++ b/selectrum.el
@@ -1288,7 +1288,6 @@ CANDIDATES is the list of strings that was passed to
 list and sorted first. If `minibuffer-default' is set it will
 have precedence over DEFAULT-CANDIDATE."
   (setq-local selectrum-active-p t)
-  (setq-local minibuffer-allow-text-properties t)
   (setq-local resize-mini-windows 'grow-only)
   (setq-local max-mini-window-height
               (1+ selectrum-num-candidates-displayed))
@@ -1685,6 +1684,7 @@ semantics of `cl-defun'."
     (setq selectrum--match-required-p require-match)
     (setq selectrum--move-default-candidate-p (not no-move-default-candidate))
     (let* ((prompt (selectrum--remove-default-from-prompt prompt))
+           (minibuffer-allow-text-properties t)
            (res
             (minibuffer-with-setup-hook
                 (lambda ()

--- a/selectrum.el
+++ b/selectrum.el
@@ -1287,6 +1287,7 @@ CANDIDATES is the list of strings that was passed to
 `selectrum-read'. DEFAULT-CANDIDATE, if provided, is added to the
 list and sorted first. If `minibuffer-default' is set it will
 have precedence over DEFAULT-CANDIDATE."
+  (setq-local selectrum-active-p t)
   (setq-local minibuffer-allow-text-properties t)
   (setq-local resize-mini-windows 'grow-only)
   (setq-local max-mini-window-height


### PR DESCRIPTION
Allow recursive icomplete sessions, icomplete-mode was let bound though should be unset for the current session only. This way one can start a recursive session command which uses icomplete. The code in `selectrum-read` got a bit restrucutred and the let binding for `resize-mini-windows` got removed as it can also be bound session locally. `max-mini-window-height` got removed completely as it isn't needed.