### PR TITLE
Speed up describe-variable for recursive sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog].
   of `selectrum-completion-in-region` using
   `selectrum-completion-in-region-styles` ([#331]).
 * Computation of candidates is faster for `describe-variable` ([#312],
-  [#316], [#320], [#321]).
+  [#316], [#320], [#321], [#343]).
 * Candidates of `completing-read-multiple` which are submitted by
   `selectrum-select-current-candidate` are now passed to
   `selectrum-candidate-selected-hook` one by one in the order they
@@ -208,6 +208,7 @@ The format is based on [Keep a Changelog].
 [#338]: https://github.com/raxod502/selectrum/pull/338
 [#339]: https://github.com/raxod502/selectrum/pull/339
 [#341]: https://github.com/raxod502/selectrum/pull/341
+[#343]: https://github.com/raxod502/selectrum/pull/343
 [#344]: https://github.com/raxod502/selectrum/issues/344
 [#345]: https://github.com/raxod502/selectrum/pull/345
 [#346]: https://github.com/raxod502/selectrum/pull/346

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* With commands `next-history-element` and `previous-history-element`
+  the inserted history element will get selected which helps when the
+  element isn't a member of the candidate set and fixes a problem with
+  file completions when the element is a directory. Before the first
+  file in that directory would be selected ([#323], [#324], [#341]).
 * Improved exit behaviour of `selectrum-select-current-candidate`. The
   commands gives feedback now when match is required and submission
   not possible. Also it allows submission of the prompt when a match
@@ -27,8 +32,6 @@ The format is based on [Keep a Changelog].
 * You can now configure `completion-styles` for the initial filtering
   of `selectrum-completion-in-region` using
   `selectrum-completion-in-region-styles` ([#331]).
-* The prompt gets selected when using `next-history-element` and the
-  prompt equals the default ([#323], [#324]).
 * Computation of candidates is faster for `describe-variable` ([#312],
   [#316], [#320], [#321]).
 * Candidates of `completing-read-multiple` which are submitted by
@@ -196,6 +199,7 @@ The format is based on [Keep a Changelog].
 [#337]: https://github.com/raxod502/selectrum/pull/337
 [#338]: https://github.com/raxod502/selectrum/pull/338
 [#339]: https://github.com/raxod502/selectrum/pull/339
+[#341]: https://github.com/raxod502/selectrum/pull/341
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1287,11 +1287,12 @@ TABLE defaults to `minibuffer-completion-table'. PRED defaults to
     (delete-overlay selectrum--count-overlay))
   (setq selectrum--count-overlay nil))
 
-(defun selectrum--minibuffer-setup-hook (candidates buf)
+(defun selectrum--minibuffer-setup-hook (candidates default buf)
   "Set up minibuffer for interactive candidate selection.
 CANDIDATES is the list of strings that was passed to
-`selectrum-read' and BUF the buffer the session was started
-from."
+`selectrum-read'. DEFAULT is the default value which can be
+overridden by `minibuffer-default' and BUF the buffer the session
+was started from."
   (setq-local selectrum-active-p t)
   (setq-local selectrum--last-buffer buf)
   (setq-local auto-hscroll-mode t)
@@ -1318,7 +1319,7 @@ from."
                         candidates))
          (setq selectrum--total-num-candidates (length candidates))))
   (let ((default (or (car-safe minibuffer-default)
-                     minibuffer-default)))
+                     minibuffer-default default)))
     (setq selectrum--default-candidate
           (if (and default (symbolp default))
               (symbol-name default)
@@ -1695,7 +1696,8 @@ semantics of `cl-defun'."
            (res
             (minibuffer-with-setup-hook
                 (:append (lambda ()
-                           (selectrum--minibuffer-setup-hook candidates buf)))
+                           (selectrum--minibuffer-setup-hook
+                            candidates default-candidate buf)))
               (read-from-minibuffer
                prompt initial-input selectrum-minibuffer-map nil
                (or history 'minibuffer-history) default-candidate))))

--- a/selectrum.el
+++ b/selectrum.el
@@ -443,39 +443,6 @@ destructively and return the modified list."
         (setq link (cdr link))))
     (nconc (nreverse elts) (cdr lst))))
 
-(defun selectrum--normalize-collection (collection &optional predicate)
-  "Normalize COLLECTION into a list of strings.
-COLLECTION may be a list of strings or symbols or cons cells, an
-obarray, a hash table, or a function, as per the docstring of
-`all-completions'. The returned list may be mutated without
-damaging the original COLLECTION.
-
-If PREDICATE is non-nil, then it filters the collection as in
-`all-completions'."
-  ;; Making the last buffer current avoids the cost of potential
-  ;; buffer switching for each candidate within the predicate (see
-  ;; `describe-variable').
-  (with-current-buffer (if (eq collection 'help--symbol-completion-table)
-                           selectrum--last-buffer
-                         (current-buffer))
-    (let ((completion-regexp-list nil))
-      (all-completions "" collection predicate))))
-
-(defun selectrum--remove-default-from-prompt (prompt)
-  "Remove the indication of the default value from PROMPT.
-Selectrum has its own methods for indicating the default value,
-making other methods redundant."
-  (save-match-data
-    (let ((regexps selectrum--minibuffer-default-in-prompt-regexps))
-      (cl-dolist (matcher regexps prompt)
-        (let ((regex (if (stringp matcher) matcher (car matcher))))
-          (when (string-match regex prompt)
-            (cl-return
-             (replace-match "" nil nil prompt
-                            (if (consp matcher)
-                                (cadr matcher)
-                              0)))))))))
-
 ;;;; Minibuffer state
 
 ;;;;; Variables
@@ -581,6 +548,39 @@ This is non-nil during the first call of
   "Buffer to display candidates using `selectrum-display-action'.")
 
 ;;;;; Utility functions
+
+(defun selectrum--normalize-collection (collection &optional predicate)
+  "Normalize COLLECTION into a list of strings.
+COLLECTION may be a list of strings or symbols or cons cells, an
+obarray, a hash table, or a function, as per the docstring of
+`all-completions'. The returned list may be mutated without
+damaging the original COLLECTION.
+
+If PREDICATE is non-nil, then it filters the collection as in
+`all-completions'."
+  ;; Making the last buffer current avoids the cost of potential
+  ;; buffer switching for each candidate within the predicate (see
+  ;; `describe-variable').
+  (with-current-buffer (if (eq collection 'help--symbol-completion-table)
+                           selectrum--last-buffer
+                         (current-buffer))
+    (let ((completion-regexp-list nil))
+      (all-completions "" collection predicate))))
+
+(defun selectrum--remove-default-from-prompt (prompt)
+  "Remove the indication of the default value from PROMPT.
+Selectrum has its own methods for indicating the default value,
+making other methods redundant."
+  (save-match-data
+    (let ((regexps selectrum--minibuffer-default-in-prompt-regexps))
+      (cl-dolist (matcher regexps prompt)
+        (let ((regex (if (stringp matcher) matcher (car matcher))))
+          (when (string-match regex prompt)
+            (cl-return
+             (replace-match "" nil nil prompt
+                            (if (consp matcher)
+                                (cadr matcher)
+                              0)))))))))
 
 (defun selectrum-get-current-candidate (&optional notfull)
   "Return currently selected Selectrum candidate.

--- a/selectrum.el
+++ b/selectrum.el
@@ -443,39 +443,6 @@ destructively and return the modified list."
         (setq link (cdr link))))
     (nconc (nreverse elts) (cdr lst))))
 
-(defun selectrum--normalize-collection (collection &optional predicate)
-  "Normalize COLLECTION into a list of strings.
-COLLECTION may be a list of strings or symbols or cons cells, an
-obarray, a hash table, or a function, as per the docstring of
-`all-completions'. The returned list may be mutated without
-damaging the original COLLECTION.
-
-If PREDICATE is non-nil, then it filters the collection as in
-`all-completions'."
-  ;; Making the last buffer current avoids the cost of potential
-  ;; buffer switching for each candidate within the predicate (see
-  ;; `describe-variable').
-  (with-current-buffer (if (eq collection 'help--symbol-completion-table)
-                           selectrum--last-buffer
-                         (current-buffer))
-    (let ((completion-regexp-list nil))
-      (all-completions "" collection predicate))))
-
-(defun selectrum--remove-default-from-prompt (prompt)
-  "Remove the indication of the default value from PROMPT.
-Selectrum has its own methods for indicating the default value,
-making other methods redundant."
-  (save-match-data
-    (let ((regexps selectrum--minibuffer-default-in-prompt-regexps))
-      (cl-dolist (matcher regexps prompt)
-        (let ((regex (if (stringp matcher) matcher (car matcher))))
-          (when (string-match regex prompt)
-            (cl-return
-             (replace-match "" nil nil prompt
-                            (if (consp matcher)
-                                (cadr matcher)
-                              0)))))))))
-
 ;;;; Minibuffer state
 
 (defvar-local selectrum--last-buffer nil
@@ -579,6 +546,39 @@ This is non-nil during the first call of
   "Buffer to display candidates using `selectrum-display-action'.")
 
 ;;;;; Minibuffer state utility functions
+
+(defun selectrum--normalize-collection (collection &optional predicate)
+  "Normalize COLLECTION into a list of strings.
+COLLECTION may be a list of strings or symbols or cons cells, an
+obarray, a hash table, or a function, as per the docstring of
+`all-completions'. The returned list may be mutated without
+damaging the original COLLECTION.
+
+If PREDICATE is non-nil, then it filters the collection as in
+`all-completions'."
+  ;; Making the last buffer current avoids the cost of potential
+  ;; buffer switching for each candidate within the predicate (see
+  ;; `describe-variable').
+  (with-current-buffer (if (eq collection 'help--symbol-completion-table)
+                           selectrum--last-buffer
+                         (current-buffer))
+    (let ((completion-regexp-list nil))
+      (all-completions "" collection predicate))))
+
+(defun selectrum--remove-default-from-prompt (prompt)
+  "Remove the indication of the default value from PROMPT.
+Selectrum has its own methods for indicating the default value,
+making other methods redundant."
+  (save-match-data
+    (let ((regexps selectrum--minibuffer-default-in-prompt-regexps))
+      (cl-dolist (matcher regexps prompt)
+        (let ((regex (if (stringp matcher) matcher (car matcher))))
+          (when (string-match regex prompt)
+            (cl-return
+             (replace-match "" nil nil prompt
+                            (if (consp matcher)
+                                (cadr matcher)
+                              0)))))))))
 
 (defun selectrum-get-current-candidate (&optional notfull)
   "Return currently selected Selectrum candidate if there is one.

--- a/selectrum.el
+++ b/selectrum.el
@@ -1291,7 +1291,8 @@ TABLE defaults to `minibuffer-completion-table'. PRED defaults to
 CANDIDATES is the list of strings that was passed to
 `selectrum-read'. DEFAULT-CANDIDATE, if provided, is added to the
 list and sorted first. If `minibuffer-default' is set it will
-have precedence over DEFAULT-CANDIDATE."
+have precedence over DEFAULT-CANDIDATE. LAST-BUFFER is the buffer
+the session was started from."
   (setq-local selectrum-active-p t)
   (setq-local selectrum--last-buffer last-buffer)
   (add-hook

--- a/selectrum.el
+++ b/selectrum.el
@@ -1290,7 +1290,8 @@ TABLE defaults to `minibuffer-completion-table'. PRED defaults to
 (defun selectrum--minibuffer-setup-hook (candidates buf)
   "Set up minibuffer for interactive candidate selection.
 CANDIDATES is the list of strings that was passed to
-`selectrum-read'."
+`selectrum-read' and BUF the buffer the session was started
+from."
   (setq-local selectrum-active-p t)
   (setq-local selectrum--last-buffer buf)
   (setq-local auto-hscroll-mode t)


### PR DESCRIPTION
This adds a variable to keep track of the buffer which entered the current session. This can also be used to fix the remaining problems with the slowdown of `describe-variable` in recursive sessions as discussed in #321.