### PR TITLE
Improve prompt selection for history commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ The format is based on [Keep a Changelog].
 
 ### Enhancements
 * With commands `next-history-element` and `previous-history-element`
-  the inserted history element will get selected which helps when the
-  element isn't a member of the candidate set and fixes a problem with
-  file completions when the element is a directory. Before the first
-  file in that directory would be selected ([#323], [#324], [#341]).
+  the inserted history element will get selected when a match isn't
+  required which helps when the element isn't a member of the
+  candidate set and also fixes a problem with file completions when
+  the element is a directory. Before the first file in that directory
+  would be selected ([#323], [#324], [#341], [#346]).
 * Improved exit behaviour of `selectrum-select-current-candidate`. The
   commands gives feedback now when match is required and submission
   not possible. Also it allows submission of the prompt when a match
@@ -205,6 +206,7 @@ The format is based on [Keep a Changelog].
 [#341]: https://github.com/raxod502/selectrum/pull/341
 [#344]: https://github.com/raxod502/selectrum/issues/344
 [#345]: https://github.com/raxod502/selectrum/pull/345
+[#346]: https://github.com/raxod502/selectrum/pull/346
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -821,7 +821,8 @@ the update."
                                   (minibuffer-contents)))
                       (and (not (= (minibuffer-prompt-end) (point-max)))
                            (memq this-command '(next-history-element
-                                                previous-history-element))))
+                                                previous-history-element))
+                           (not selectrum--match-required-p)))
                   -1)
                  (selectrum--move-default-candidate-p
                   0)


### PR DESCRIPTION
It is better to keep the prompt unselected when a match is required for history commands, too. Currently deselection of the prompt after a history command would not always end up cleaning the prompt up and also for commands which use input history it makes no sense to have the prompt selected. Follow up to #341 
