### PR TITLE
Fix selectrum-get-current-candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ The format is based on [Keep a Changelog].
   they contain ([#266], [#302], [#318]).
 
 ### Bugs fixed
+* When there were no candidates `selectrum-get-current-candidate`
+  would throw an error, which has been fixed ([#347]).
 * When `auto-hscroll-mode` was set to `current-line` prompts which
   exceeded the frame width would introduce constant back and forth
   scrolling issues, which has been fixed ([#344], [#345]).
@@ -207,6 +209,7 @@ The format is based on [Keep a Changelog].
 [#344]: https://github.com/raxod502/selectrum/issues/344
 [#345]: https://github.com/raxod502/selectrum/pull/345
 [#346]: https://github.com/raxod502/selectrum/pull/346
+[#347]: https://github.com/raxod502/selectrum/pull/347
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -578,11 +578,12 @@ This is non-nil during the first call of
 ;;;;; Minibuffer state utility functions
 
 (defun selectrum-get-current-candidate (&optional notfull)
-  "Return currently selected Selectrum candidate.
+  "Return currently selected Selectrum candidate if there is one.
 If NOTFULL is non-nil don't use canonical representation of
 candidate and return the candidate as displayed."
   (when (and selectrum-active-p
-             selectrum--current-candidate-index)
+             selectrum--current-candidate-index
+             selectrum--refined-candidates)
     (if notfull
         (selectrum--get-candidate
          selectrum--current-candidate-index)


### PR DESCRIPTION
See #336, selectrum-get-current-candidate would throw an error when there are no candidates
