### PR TITLE
Always check available candidates before setting index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog].
 ### Features
 * `selectrum-exhibit` got an optional argument which allows to keep
   the current candidate selected after the update which is helpful for
-  async completions ([#306], [#307]).
+  async completions ([#306], [#307], [#349]).
 * The user option `selectrum-display-action` can be used to show
   candidates in another window or frame ([#230], [#309]).
 * The user option `selectrum-show-indices` can now be a function that
@@ -211,6 +211,7 @@ The format is based on [Keep a Changelog].
 [#346]: https://github.com/raxod502/selectrum/pull/346
 [#347]: https://github.com/raxod502/selectrum/pull/347
 [#348]: https://github.com/raxod502/selectrum/pull/348
+[#349]: https://github.com/raxod502/selectrum/pull/349
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -804,15 +804,16 @@ the update."
               (setq selectrum--repeat nil))
           (setq selectrum--current-candidate-index
                 (cond
+                 ;; Check for candidates needs to be first!
+                 ((null selectrum--refined-candidates)
+                  (when (not selectrum--match-required-p)
+                    -1))
                  (keep-selected
                   (or (cl-position keep-selected
                                    selectrum--refined-candidates
                                    :key #'selectrum--get-full
                                    :test #'equal)
                       0))
-                 ((null selectrum--refined-candidates)
-                  (when (not selectrum--match-required-p)
-                    -1))
                  ((and selectrum--default-candidate
                        (string-empty-p (minibuffer-contents))
                        (not (member selectrum--default-candidate


### PR DESCRIPTION
The computation for the non candidates case needs to come first in order to avoid setting incorrect index, see #336.