### PR TITLE
Use passed default if minibuffer-default unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ The format is based on [Keep a Changelog].
 
 ### Bugs fixed
 * Selectrum did not set `minibuffer-default` for the current
-  completion session, which has been fixed ([#350], [#352]).
+  completion session, which has been fixed ([#350], [#352], [#354]).
 * When there were no candidates `selectrum-get-current-candidate`
   would throw an error, which has been fixed ([#347], [#348]).
 * When `auto-hscroll-mode` was set to `current-line` prompts which
@@ -216,6 +216,7 @@ The format is based on [Keep a Changelog].
 [#349]: https://github.com/raxod502/selectrum/pull/349
 [#350]: https://github.com/raxod502/selectrum/issues/350
 [#352]: https://github.com/raxod502/selectrum/pull/352
+[#354]: https://github.com/raxod502/selectrum/pull/354
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1284,7 +1284,7 @@ TABLE defaults to `minibuffer-completion-table'. PRED defaults to
     (delete-overlay selectrum--count-overlay))
   (setq selectrum--count-overlay nil))
 
-(defun selectrum--minibuffer-setup-hook (candidates)
+(defun selectrum--minibuffer-setup-hook (candidates default)
   "Set up minibuffer for interactive candidate selection.
 CANDIDATES is the list of strings that was passed to
 `selectrum-read'."
@@ -1313,7 +1313,7 @@ CANDIDATES is the list of strings that was passed to
                         candidates))
          (setq selectrum--total-num-candidates (length candidates))))
   (let ((default (or (car-safe minibuffer-default)
-                     minibuffer-default)))
+                     minibuffer-default default)))
     (setq selectrum--default-candidate
           (if (and default (symbolp default))
               (symbol-name default)
@@ -1682,7 +1682,7 @@ semantics of `cl-defun'."
     (minibuffer-with-setup-hook
         (:append (lambda ()
                    (selectrum--minibuffer-setup-hook
-                    candidates)))
+                    candidates default-candidate)))
       (let* ((minibuffer-allow-text-properties t)
              (resize-mini-windows 'grow-only)
              (max-mini-window-height

--- a/selectrum.el
+++ b/selectrum.el
@@ -1287,7 +1287,8 @@ TABLE defaults to `minibuffer-completion-table'. PRED defaults to
 (defun selectrum--minibuffer-setup-hook (candidates default)
   "Set up minibuffer for interactive candidate selection.
 CANDIDATES is the list of strings that was passed to
-`selectrum-read'."
+`selectrum-read'. DEFAULT is the default value which can be
+overridden by `minibuffer-default'."
   (setq-local auto-hscroll-mode t)
   (setq-local selectrum-active-p t)
   (add-hook


### PR DESCRIPTION
Follow up for #352, turns out `read-from-minibuffer` does not set `minibuffer-default`.
