### PR TITLE
Improve history browsing with remote paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* When using `next-history-element` or `previous-history-element`
+  don't automatically open tramp connections for remote paths. To
+  trigger tramp for a selected history element you can use
+  `selectrum-insert-current-candidate` ([#358]).
 * In file completions the prompt will also be selected when a match is
   required and the path exists ([#357]).
 * With commands `next-history-element` and `previous-history-element`
@@ -222,6 +226,7 @@ The format is based on [Keep a Changelog].
 [#354]: https://github.com/raxod502/selectrum/pull/354
 [#356]: https://github.com/raxod502/selectrum/pull/356
 [#357]: https://github.com/raxod502/selectrum/pull/357
+[#358]: https://github.com/raxod502/selectrum/pull/358
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1505,7 +1505,8 @@ inserted automatically when using
 Give a prefix argument ARG to select the nth displayed candidate.
 Zero means to select the current user input. See
 `selectrum-show-indices' which can be used to show candidate
-indices."
+indices. When the prompt is selected this command triggers a
+refresh."
   (interactive "P")
   (with-selected-window (active-minibuffer-window)
     (if-let ((index (selectrum--index-for-arg arg))
@@ -1938,22 +1939,37 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                    ;; The input used for matching current dir entries.
                    (matchstr (file-name-nondirectory input))
                    (cands
-                    (cond ((equal last-dir dir)
-                           (setq-local selectrum-preprocess-candidates-function
-                                       #'identity)
-                           selectrum--preprocessed-candidates)
-                          (t
-                           (setq-local selectrum-preprocess-candidates-function
-                                       sortf)
-                           (condition-case _
-                               (delete
-                                "./"
-                                (delete
-                                 "../"
-                                 (funcall collection dir predicate t)))
-                             ;; May happen in case user quits out
-                             ;; of a TRAMP prompt.
-                             (quit))))))
+                    (cond
+                     ((and (equal last-dir dir)
+                           ;; Force refresh and give tramp a chance to
+                           ;; trigger.
+                           (not (eq this-command
+                                    'selectrum-insert-current-candidate)))
+                      (setq-local selectrum-preprocess-candidates-function
+                                  #'identity)
+                      selectrum--preprocessed-candidates)
+                     (t
+                      (setq-local selectrum-preprocess-candidates-function
+                                  sortf)
+                      (condition-case _
+                          (let* ((insertp
+                                  (eq this-command
+                                      'selectrum-insert-current-candidate))
+                                 ;; Don't trigger tramp when browsing
+                                 ;; history, unless requested.
+                                 (non-essential
+                                  (and (not insertp)
+                                       (memq this-command
+                                             '(previous-history-element
+                                               next-history-element)))))
+                            (delete
+                             "./"
+                             (delete
+                              "../"
+                              (funcall collection dir predicate t))))
+                        ;; May happen in case user quits out
+                        ;; of a TRAMP prompt.
+                        (quit))))))
               (setq last-dir dir)
               `((input . ,matchstr)
                 (candidates . ,cands))))))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1951,25 +1951,25 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                      (t
                       (setq-local selectrum-preprocess-candidates-function
                                   sortf)
-                      (condition-case _
-                          (let* ((insertp
-                                  (eq this-command
-                                      'selectrum-insert-current-candidate))
-                                 ;; Don't trigger tramp when browsing
-                                 ;; history, unless requested.
-                                 (non-essential
-                                  (and (not insertp)
-                                       (memq this-command
-                                             '(previous-history-element
-                                               next-history-element)))))
+                      (let* ((insertp
+                              (eq this-command
+                                  'selectrum-insert-current-candidate))
+                             ;; Don't trigger tramp when browsing
+                             ;; history, unless requested.
+                             (non-essential
+                              (and (not insertp)
+                                   (memq this-command
+                                         '(previous-history-element
+                                           next-history-element)))))
+                        (condition-case _
                             (delete
                              "./"
                              (delete
                               "../"
-                              (funcall collection dir predicate t))))
-                        ;; May happen in case user quits out
-                        ;; of a TRAMP prompt.
-                        (quit))))))
+                              (funcall collection dir predicate t)))
+                          ;; May happen in case user quits out
+                          ;; of a TRAMP prompt.
+                          (quit)))))))
               (setq last-dir dir)
               `((input . ,matchstr)
                 (candidates . ,cands))))))


### PR DESCRIPTION
Don't trigger tramp automatically when using history commands. If one wants to trigger tramp for the current history item one can use `'selectrum-insert-current-candidate` to force a refresh.
