### PR TITLE
Ensure mini window resets scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* When using commands where the prompt would exceed the window with
+  the horizontal scroll wouldn't reset afterwards when a smaller
+  element was pulled into the prompt under certain conditions (for
+  example when using history commands), which has been fixed ([#360]).
 * When using `next-history-element` or `previous-history-element`
   don't automatically open tramp connections for remote paths. To
   trigger tramp for a selected history element you can use
@@ -227,6 +231,7 @@ The format is based on [Keep a Changelog].
 [#356]: https://github.com/raxod502/selectrum/pull/356
 [#357]: https://github.com/raxod502/selectrum/pull/357
 [#358]: https://github.com/raxod502/selectrum/pull/358
+[#360]: https://github.com/raxod502/selectrum/pull/360
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
-* When using commands where the prompt would exceed the window with
+* When using commands where the prompt would exceed the window width
   the horizontal scroll wouldn't reset afterwards when a smaller
   element was pulled into the prompt under certain conditions (for
   example when using history commands), which has been fixed ([#360]).

--- a/selectrum.el
+++ b/selectrum.el
@@ -740,6 +740,9 @@ the update."
     (goto-char (max (point) (minibuffer-prompt-end)))
     ;; For some reason this resets and thus can't be set in setup hook.
     (setq-local truncate-lines t)
+    ;; Esnure minibuffer window resets any scroll, for example history
+    ;; commands can increase scroll but fail to reset it.
+    (set-window-hscroll (active-minibuffer-window) 0)
     (let ((inhibit-read-only t)
           ;; Don't record undo information while messing with the
           ;; minibuffer, as per


### PR DESCRIPTION
When using commands where the prompt would exceed the window width
  the horizontal scroll wouldn't reset afterwards when a smaller
  element was pulled into the prompt under certain conditions (for
  example when using history commands), which has been fixed