### PR TITLE
Improve history usage in file completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog].
 * `selectrum-insert-current-candidate` will reset
   `minibuffer-history-position`, so that after "choosing" an item and
   using other history commands in succession the history will start
-  from the beginnging ([#361]).
+  from the beginning ([#361]).
 * History commands don't automatically trigger a refresh in file
   completions. This is especially useful to prevent unintended opening
   of tramp connections. To trigger a refresh for a selected history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* When the prompt is empty and the default value is shown you can now
+  insert it using `selectrum-insert-current-candidate` ([#359]).
 * When using `next-history-element` or `previous-history-element`
   don't automatically open tramp connections for remote paths. To
   trigger tramp for a selected history element you can use
@@ -227,6 +229,7 @@ The format is based on [Keep a Changelog].
 [#356]: https://github.com/raxod502/selectrum/pull/356
 [#357]: https://github.com/raxod502/selectrum/pull/357
 [#358]: https://github.com/raxod502/selectrum/pull/358
+[#359]: https://github.com/raxod502/selectrum/pull/359
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,14 @@ The format is based on [Keep a Changelog].
 * When the prompt is empty and the default value is shown you can now
   insert it using `selectrum-insert-current-candidate` ([#359]).
 * `selectrum-insert-current-candidate` will reset
-  `minibuffer-history-position`, so with repeated use of history
-  commands after choosing items from history previously, you restart
-  from the beginning ([#361]).
-* When using history commands don't automatically trigger a refresh.
-  This is especially useful to prevent unintended opening of tramp
-  connections for remote paths. To trigger a refresh for a selected
-  history element you can use `selectrum-insert-current-candidate`
-  ([#358], [#361]).
+  `minibuffer-history-position`, so that after "choosing" an item and
+  using other history commands in succession the history will start
+  from the beginnging ([#361]).
+* History commands don't automatically trigger a refresh in file
+  completions. This is especially useful to prevent unintended opening
+  of tramp connections. To trigger a refresh for a selected history
+  element you can use `selectrum-insert-current-candidate` ([#358],
+  [#361]).
 * In file completions the prompt will also be selected when a match is
   required and the path exists ([#357]).
 * With commands `next-history-element` and `previous-history-element`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,9 @@ The format is based on [Keep a Changelog].
 * When the prompt is empty and the default value is shown you can now
   insert it using `selectrum-insert-current-candidate` ([#359]).
 * `selectrum-insert-current-candidate` will reset
-  `minibuffer-history-position`, so when using history commands again
-  after choosing an item from history previously you start from the
-  beginning ([#361]).
+  `minibuffer-history-position`, so with repeated use of history
+  commands after choosing items from history previously, you restart
+  from the beginning ([#361]).
 * When using history commands don't automatically trigger a refresh.
   This is especially useful to prevent unintended opening of tramp
   connections for remote paths. To trigger a refresh for a selected
@@ -240,6 +240,7 @@ The format is based on [Keep a Changelog].
 [#358]: https://github.com/raxod502/selectrum/pull/358
 [#359]: https://github.com/raxod502/selectrum/pull/359
 [#360]: https://github.com/raxod502/selectrum/pull/360
+[#361]: https://github.com/raxod502/selectrum/pull/361
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The format is based on [Keep a Changelog].
   insert it using `selectrum-insert-current-candidate` ([#359]).
 * `selectrum-insert-current-candidate` will reset
   `minibuffer-history-position`, so when using history commands again
-  after choosing an item from histroy previously you start from the
+  after choosing an item from history previously you start from the
   beginning ([#361]).
 * When using history commands don't automatically trigger a refresh.
   This is especially useful to prevent unintended opening of tramp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,15 @@ The format is based on [Keep a Changelog].
   example when using history commands), which has been fixed ([#360]).
 * When the prompt is empty and the default value is shown you can now
   insert it using `selectrum-insert-current-candidate` ([#359]).
-* When using `next-history-element` or `previous-history-element`
-  don't automatically open tramp connections for remote paths. To
-  trigger tramp for a selected history element you can use
-  `selectrum-insert-current-candidate` ([#358]).
+* `selectrum-insert-current-candidate` will reset
+  `minibuffer-history-position`, so when using history commands again
+  after choosing an item from histroy previously you start from the
+  beginning ([#361]).
+* When using history commands don't automatically trigger a refresh.
+  This is especially useful to prevent unintended opening of tramp
+  connections for remote paths. To trigger a refresh for a selected
+  history element you can use `selectrum-insert-current-candidate`
+  ([#358], [#361]).
 * In file completions the prompt will also be selected when a match is
   required and the path exists ([#357]).
 * With commands `next-history-element` and `previous-history-element`

--- a/selectrum.el
+++ b/selectrum.el
@@ -1963,8 +1963,9 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                       (setq-local selectrum-preprocess-candidates-function
                                   sortf)
                       (let ((non-essential
-                             (and minibuffer-history-position
-                                  (not (zerop minibuffer-history-position)))))
+                             (or (and minibuffer-history-position
+                                      (not (zerop minibuffer-history-position)))
+                                 non-essential)))
                         (condition-case _
                             (delete
                              "./"

--- a/selectrum.el
+++ b/selectrum.el
@@ -1948,7 +1948,8 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                    (matchstr (file-name-nondirectory input))
                    (cands
                     (cond
-                     ((not (zerop minibuffer-history-position))
+                     ((and minibuffer-history-position
+                           (not (zerop minibuffer-history-position)))
                       nil)
                      ((and (equal last-dir dir)
                            ;; Allow forcing refresh.
@@ -1961,7 +1962,8 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                       (setq-local selectrum-preprocess-candidates-function
                                   sortf)
                       (let ((non-essential
-                             (not (zerop minibuffer-history-position))))
+                             (and minibuffer-history-position
+                                  (not (zerop minibuffer-history-position)))))
                         (condition-case _
                             (delete
                              "./"

--- a/selectrum.el
+++ b/selectrum.el
@@ -1514,8 +1514,11 @@ refresh."
              (full (selectrum--get-full candidate)))
         (progn
           ;; Ignore for prompt selection.
-          (unless (and selectrum--current-candidate-index
-                       (< selectrum--current-candidate-index 0))
+          (if (and selectrum--current-candidate-index
+                   (< selectrum--current-candidate-index 0))
+              (when (and (= (minibuffer-prompt-end) (point-max))
+                         selectrum--default-candidate)
+                (insert selectrum--default-candidate))
             (cond ((not selectrum--crm-p)
                    (delete-region (minibuffer-prompt-end)
                                   (point-max))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1545,7 +1545,9 @@ refresh."
           ;; Ensure refresh of UI. The input input string might be the
           ;; same when the prompt was reinserted. When the prompt was
           ;; selected this will switch selection to first candidate.
-          (setq selectrum--previous-input-string nil))
+          (setq selectrum--previous-input-string nil)
+          ;; Reset history as current candidate was accepted.
+          (setq-local minibuffer-history-position 0))
       (unless completion-fail-discreetly
         (ding)
         (minibuffer-message "No match")))))
@@ -1946,9 +1948,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                    (matchstr (file-name-nondirectory input))
                    (cands
                     (cond
-                     ((and (not (zerop minibuffer-history-position))
-                           (not (eq this-command
-                                    'selectrum-insert-current-candidate)))
+                     ((not (zerop minibuffer-history-position))
                       nil)
                      ((and (equal last-dir dir)
                            ;; Allow forcing refresh.
@@ -1961,10 +1961,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                       (setq-local selectrum-preprocess-candidates-function
                                   sortf)
                       (let ((non-essential
-                             (and (not (zerop minibuffer-history-position))
-                                  (not
-                                   (eq this-command
-                                       'selectrum-insert-current-candidate)))))
+                             (not (zerop minibuffer-history-position))))
                         (condition-case _
                             (delete
                              "./"

--- a/selectrum.el
+++ b/selectrum.el
@@ -1962,7 +1962,8 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                   sortf)
                       (let ((non-essential
                              (or (and minibuffer-history-position
-                                      (not (zerop minibuffer-history-position)))
+                                      (not (zerop
+                                            minibuffer-history-position)))
                                  non-essential)))
                         (condition-case _
                             (delete

--- a/selectrum.el
+++ b/selectrum.el
@@ -1967,11 +1967,11 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                        'selectrum-insert-current-candidate)))))
                         (condition-case _
                             (prog1
-                              (delete
-                               "./"
-                               (delete
-                                "../"
-                                (funcall collection dir predicate t)))
+                                (delete
+                                 "./"
+                                 (delete
+                                  "../"
+                                  (funcall collection dir predicate t)))
                               (setq-local minibuffer-history-position 0))
                           ;; May happen in case user quits out
                           ;; of a TRAMP prompt.

--- a/selectrum.el
+++ b/selectrum.el
@@ -1938,7 +1938,6 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
             HIST, DEF, _INHERIT-INPUT-METHOD see `completing-read'."
   (let* ((last-dir nil)
          (sortf nil)
-         (msg nil)
          (coll
           (lambda (input)
             (let* (;; Full path of input dir (might include shadowed parts).
@@ -1950,12 +1949,6 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                      ((and (not (zerop minibuffer-history-position))
                            (not (eq this-command
                                     'selectrum-insert-current-candidate)))
-                      (minibuffer-message
-                       (concat
-                        (format "%s/%s "
-                                minibuffer-history-position
-                                (length (symbol-value minibuffer-history-variable)))
-                        msg))
                       nil)
                      ((and (equal last-dir dir)
                            ;; Allow forcing refresh.
@@ -1993,10 +1986,6 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                    ;; Pickup the value as configured for current
                    ;; session.
                    (setq sortf selectrum-preprocess-candidates-function)
-                   (setq msg (propertize
-                              (substitute-command-keys
-                               "Press \\[selectrum-insert-current-candidate] to refresh")
-                              'face 'minibuffer-prompt))
                    ;; Ensure the variable is also set when
                    ;; selectrum--completing-read-file-name is called
                    ;; directly.

--- a/selectrum.el
+++ b/selectrum.el
@@ -837,10 +837,8 @@ the update."
                            (equal selectrum--default-candidate
                                   (minibuffer-contents)))
                       (and (not (= (minibuffer-prompt-end) (point-max)))
-                           (or (memq this-command '(next-history-element
-                                                    previous-history-element))
-                               (and minibuffer-history-position
-                                    (not (zerop minibuffer-history-position))))
+                           (and minibuffer-history-position
+                                (not (zerop minibuffer-history-position)))
                            (or (not selectrum--match-required-p)
                                (selectrum--at-existing-prompt-path-p))))
                   -1)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1966,13 +1966,11 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                    (eq this-command
                                        'selectrum-insert-current-candidate)))))
                         (condition-case _
-                            (prog1
-                                (delete
-                                 "./"
-                                 (delete
-                                  "../"
-                                  (funcall collection dir predicate t)))
-                              (setq-local minibuffer-history-position 0))
+                            (delete
+                             "./"
+                             (delete
+                              "../"
+                              (funcall collection dir predicate t)))
                           ;; May happen in case user quits out
                           ;; of a TRAMP prompt.
                           (quit)))))))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1954,9 +1954,8 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                            (not (zerop minibuffer-history-position)))
                       nil)
                      ((and (equal last-dir dir)
-                           ;; Allow forcing refresh.
-                           (not (eq this-command
-                                    'selectrum-insert-current-candidate)))
+                           (not (and minibuffer-history-position
+                                     (zerop minibuffer-history-position))))
                       (setq-local selectrum-preprocess-candidates-function
                                   #'identity)
                       selectrum--preprocessed-candidates)

--- a/selectrum.el
+++ b/selectrum.el
@@ -837,8 +837,10 @@ the update."
                            (equal selectrum--default-candidate
                                   (minibuffer-contents)))
                       (and (not (= (minibuffer-prompt-end) (point-max)))
-                           (memq this-command '(next-history-element
-                                                previous-history-element))
+                           (or (memq this-command '(next-history-element
+                                                    previous-history-element))
+                               (and minibuffer-history-position
+                                    (not (zerop minibuffer-history-position))))
                            (or (not selectrum--match-required-p)
                                (selectrum--at-existing-prompt-path-p))))
                   -1)


### PR DESCRIPTION
Reset minibuffer-history-postion when using `selectrum-insert-current-candidate` and for file browsing do not trigger a refresh when using history commands generally unless requested (maybe this behaviour could also be useful in general not only for file browsing?).
