### PR TITLE
Fix up #361

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ The format is based on [Keep a Changelog].
   completions. This is especially useful to prevent unintended opening
   of tramp connections. To trigger a refresh for a selected history
   element you can use `selectrum-insert-current-candidate` ([#358],
-  [#361]).
+  [#361], [#365]).
 * In file completions the prompt will also be selected when a match is
   required and the path exists ([#357]).
 * With commands `next-history-element` and `previous-history-element`
@@ -255,6 +255,7 @@ The format is based on [Keep a Changelog].
 [#360]: https://github.com/raxod502/selectrum/pull/360
 [#361]: https://github.com/raxod502/selectrum/pull/361
 [#362]: https://github.com/raxod502/selectrum/pull/362
+[#365]: https://github.com/raxod502/selectrum/pull/365
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1954,8 +1954,8 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                            (not (zerop minibuffer-history-position)))
                       nil)
                      ((and (equal last-dir dir)
-                           (not (and minibuffer-history-position
-                                     (zerop minibuffer-history-position))))
+                           (not (eq this-command
+                                    'selectrum-insert-current-candidate)))
                       (setq-local selectrum-preprocess-candidates-function
                                   #'identity)
                       selectrum--preprocessed-candidates)


### PR DESCRIPTION
It is better to check for `selectrum-insert-current-candidate` as `minibuffer-history-postion` is zero by default.
