### PR TITLE
Improve history browsing with file completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog].
 * `selectrum-insert-current-candidate` will reset
   `minibuffer-history-position`, so that after "choosing" an item and
   using other history commands in succession the history will start
-  from the beginning ([#361]).
+  from the beginning ([#361], [#368]).
 * History commands don't automatically trigger a refresh in file
   completions. This is especially useful to prevent unintended opening
   of tramp connections. To trigger a refresh for a selected history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,12 @@ The format is based on [Keep a Changelog].
 * `selectrum-insert-current-candidate` will reset
   `minibuffer-history-position`, so that after "choosing" an item and
   using other history commands in succession the history will start
-  from the beginning ([#361], [#367], [#368]).
+  from the beginning ([#361]).
 * History commands don't automatically trigger a refresh in file
   completions. This is especially useful to prevent unintended opening
   of tramp connections. To trigger a refresh for a selected history
   element you can use `selectrum-insert-current-candidate` ([#358],
-  [#361], [#365]).
+  [#361], [#365], [#367], [#368]).
 * In file completions the prompt will also be selected when a match is
   required and the path exists ([#357]).
 * With commands `next-history-element` and `previous-history-element`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog].
 * `selectrum-insert-current-candidate` will reset
   `minibuffer-history-position`, so that after "choosing" an item and
   using other history commands in succession the history will start
-  from the beginning ([#361]).
+  from the beginning ([#361], [#367], [#368]).
 * History commands don't automatically trigger a refresh in file
   completions. This is especially useful to prevent unintended opening
   of tramp connections. To trigger a refresh for a selected history
@@ -256,6 +256,8 @@ The format is based on [Keep a Changelog].
 [#361]: https://github.com/raxod502/selectrum/pull/361
 [#362]: https://github.com/raxod502/selectrum/pull/362
 [#365]: https://github.com/raxod502/selectrum/pull/365
+[#367]: https://github.com/raxod502/selectrum/pull/367
+[#368]: https://github.com/raxod502/selectrum/pull/368
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1535,6 +1535,7 @@ refresh."
           (when minibuffer-history-position
             (when (and minibuffer-completing-file-name
                        (not (zerop minibuffer-history-position)))
+              ;; Choosing a history item needs to trigger a refresh.
               (setq-local selectrum--refresh-next-file-completion t))
             ;; Reset history state as current candidate was accepted.
             (setq-local minibuffer-history-position 0)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1998,16 +1998,16 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
     (minibuffer-with-setup-hook
         ;; The hook needs to run late as `read-file-name-default' sets
         ;; its own syntax table in `minibuffer-with-setup-hook'.
-        (lambda ()
-          ;; Pickup the value as configured for current
-          ;; session.
-          (setq sortf selectrum-preprocess-candidates-function)
-          ;; Ensure the variable is also set when
-          ;; selectrum--completing-read-file-name is called
-          ;; directly.
-          (setq-local minibuffer-completing-file-name t)
-          (set-syntax-table
-           selectrum--minibuffer-local-filename-syntax))
+        (:append (lambda ()
+                   ;; Pickup the value as configured for current
+                   ;; session.
+                   (setq sortf selectrum-preprocess-candidates-function)
+                   ;; Ensure the variable is also set when
+                   ;; selectrum--completing-read-file-name is called
+                   ;; directly.
+                   (setq-local minibuffer-completing-file-name t)
+                   (set-syntax-table
+                    selectrum--minibuffer-local-filename-syntax)))
       (selectrum-read
        prompt coll
        :default-candidate (or (car-safe def) def)


### PR DESCRIPTION
Ensure the changes only affect the intended purpose and improve general behaviour:

- When navigating history the candidates should be shown again when returning to the start
- The history position should only reset when it was defined before
- There should be no refresh for `selectrum-insert-current-candidate` in general only when browsing through history