### PR TITLE
Improve file history browsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The format is based on [Keep a Changelog].
   completions. This is especially useful to prevent unintended opening
   of tramp connections. To trigger a refresh for a selected history
   element you can use `selectrum-insert-current-candidate` ([#358],
-  [#361], [#365], [#367], [#368]).
+  [#361], [#365], [#367], [#368], [#370]).
 * In file completions the prompt will also be selected when a match is
   required and the path exists ([#357]).
 * With commands `next-history-element` and `previous-history-element`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The format is based on [Keep a Changelog].
   paths. This is useful to prevent unintended opening of tramp
   connections. To trigger a refresh for the selected tramp path you
   can use `selectrum-insert-current-candidate` ([#358], [#361],
-  [#365], [#367], [#368], [#370]).
+  [#365], [#367], [#368], [#372]).
 * In file completions the prompt will also be selected when a match is
   required and the path exists ([#357]).
 * With commands `next-history-element` and `previous-history-element`
@@ -262,6 +262,7 @@ The format is based on [Keep a Changelog].
 [#367]: https://github.com/raxod502/selectrum/pull/367
 [#368]: https://github.com/raxod502/selectrum/pull/368
 [#369]: https://github.com/raxod502/selectrum/pull/369
+[#372]: https://github.com/raxod502/selectrum/pull/372
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,11 @@ The format is based on [Keep a Changelog].
   `minibuffer-history-position`, so that after "choosing" an item and
   using other history commands in succession the history will start
   from the beginning ([#361], [#368]).
-* History commands don't automatically trigger a refresh in file
-  completions. This is especially useful to prevent unintended opening
-  of tramp connections. To trigger a refresh for a selected history
-  element you can use `selectrum-insert-current-candidate` ([#358],
-  [#361], [#365], [#367], [#368], [#370]).
+* History commands don't automatically trigger a refresh for tramp
+  paths. This is useful to prevent unintended opening of tramp
+  connections. To trigger a refresh for the selected tramp path you
+  can use `selectrum-insert-current-candidate` ([#358], [#361],
+  [#365], [#367], [#368], [#370]).
 * In file completions the prompt will also be selected when a match is
   required and the path exists ([#357]).
 * With commands `next-history-element` and `previous-history-element`

--- a/selectrum.el
+++ b/selectrum.el
@@ -1487,7 +1487,6 @@ inserted automatically when using
 
 (defun selectrum--reset-minibuffer-history-state ()
   "Reset history for current prompt."
-  ;; Reset history state as current candidate was accepted.
   (setq-local minibuffer-history-position 0)
   (setq-local minibuffer-text-before-history
               (minibuffer-contents-no-properties)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1955,14 +1955,21 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
          (coll
           (lambda (input)
             (let* (;; Full path of input dir (might include shadowed parts).
-                   (dir (or (file-name-directory input) ""))
+                   (path (substitute-in-file-name input))
+                   (dir (or (file-name-directory path) ""))
                    ;; The input used for matching current dir entries.
-                   (matchstr (file-name-nondirectory input))
+                   (matchstr (file-name-nondirectory path))
                    (cands
                     (cond
                      ((and minibuffer-history-position
                            (not selectrum--refresh-next-file-completion)
-                           (not (zerop minibuffer-history-position)))
+                           (not (zerop minibuffer-history-position))
+                           ;; Check for tramp path.
+                           (string-match-p "\\`/[^/:]+:[^/:]*:" path))
+                      (setq last-dir dir)
+                      (minibuffer-message
+                       (substitute-command-keys
+                        "Press \\[selectrum-insert-current-candidate] to refresh"))
                       nil)
                      ((and (equal last-dir dir)
                            (not selectrum--refresh-next-file-completion)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1951,6 +1951,7 @@ PREDICATE, see `read-buffer'."
 For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
             HIST, DEF, _INHERIT-INPUT-METHOD see `completing-read'."
   (let* ((last-dir nil)
+         (msg "Press \\[selectrum-insert-current-candidate] to refresh")
          (sortf nil)
          (coll
           (lambda (input)
@@ -1962,15 +1963,14 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                    (cands
                     (cond
                      ((and minibuffer-history-position
-                           (not selectrum--refresh-next-file-completion)
                            (not (zerop minibuffer-history-position))
+                           (not selectrum--refresh-next-file-completion)
                            ;; Check for tramp path, see
                            ;; `tramp-initial-file-name-regexp'.
                            (string-match-p "\\`/[^/:]+:[^/:]*:" path))
-                      (minibuffer-message
-                       (substitute-command-keys
-                        "Press \\[selectrum-insert-current-candidate] to refresh"))
-                      nil)
+                      (prog1 nil
+                        (minibuffer-message
+                         (substitute-command-keys msg))))
                      ((and (equal last-dir dir)
                            (not selectrum--refresh-next-file-completion)
                            (not (and minibuffer-history-position

--- a/selectrum.el
+++ b/selectrum.el
@@ -1485,6 +1485,13 @@ If current `crm-separator' has a mapping the separator gets
 inserted automatically when using
 `selectrum-insert-current-candidate'.")
 
+(defun selectrum--reset-minibuffer-history-state ()
+  "Reset history for current prompt."
+  ;; Reset history state as current candidate was accepted.
+  (setq-local minibuffer-history-position 0)
+  (setq-local minibuffer-text-before-history
+              (minibuffer-contents-no-properties)))
+
 (defvar-local selectrum--refresh-next-file-completion nil
   "Non-nil when command should trigger refresh.")
 
@@ -1537,10 +1544,7 @@ refresh."
                        (not (zerop minibuffer-history-position)))
               ;; Choosing a history item needs to trigger a refresh.
               (setq-local selectrum--refresh-next-file-completion t))
-            ;; Reset history state as current candidate was accepted.
-            (setq-local minibuffer-history-position 0)
-            (setq-local minibuffer-text-before-history
-                        (minibuffer-contents-no-properties))))
+            (selectrum--reset-minibuffer-history-state)))
       (unless completion-fail-discreetly
         (ding)
         (minibuffer-message "No match")))))
@@ -1582,7 +1586,8 @@ history item and exit use `selectrum-select-current-candidate'."
       (if (get-text-property 0 'selectum--insert result)
           (progn
             (delete-minibuffer-contents)
-            (insert result))
+            (insert result)
+            (selectrum--reset-minibuffer-history-state))
         (if (and selectrum--match-required-p
                  (not (member result selectrum--refined-candidates)))
             (user-error "That history element is not one of the candidates")

--- a/selectrum.el
+++ b/selectrum.el
@@ -1967,7 +1967,6 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                            ;; Check for tramp path, see
                            ;; `tramp-initial-file-name-regexp'.
                            (string-match-p "\\`/[^/:]+:[^/:]*:" path))
-                      (setq last-dir dir)
                       (minibuffer-message
                        (substitute-command-keys
                         "Press \\[selectrum-insert-current-candidate] to refresh"))
@@ -1983,7 +1982,6 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                   #'identity)
                       selectrum--preprocessed-candidates)
                      (t
-                      (setq last-dir dir)
                       (setq-local selectrum--refresh-next-file-completion nil)
                       (setq-local selectrum-preprocess-candidates-function
                                   sortf)
@@ -2001,6 +1999,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                           ;; May happen in case user quits out
                           ;; of a TRAMP prompt.
                           (quit)))))))
+              (setq last-dir dir)
               `((input . ,matchstr)
                 (candidates . ,cands))))))
     (minibuffer-with-setup-hook

--- a/selectrum.el
+++ b/selectrum.el
@@ -1964,7 +1964,8 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                      ((and minibuffer-history-position
                            (not selectrum--refresh-next-file-completion)
                            (not (zerop minibuffer-history-position))
-                           ;; Check for tramp path.
+                           ;; Check for tramp path, see
+                           ;; `tramp-initial-file-name-regexp'.
                            (string-match-p "\\`/[^/:]+:[^/:]*:" path))
                       (setq last-dir dir)
                       (minibuffer-message

--- a/selectrum.el
+++ b/selectrum.el
@@ -1959,7 +1959,6 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                    (path (substitute-in-file-name input))
                    (dir (or (file-name-directory path) ""))
                    ;; The input used for matching current dir entries.
-                   ;; trigger CI rebuild
                    (matchstr (file-name-nondirectory path))
                    (cands
                     (cond

--- a/selectrum.el
+++ b/selectrum.el
@@ -1959,6 +1959,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                    (path (substitute-in-file-name input))
                    (dir (or (file-name-directory path) ""))
                    ;; The input used for matching current dir entries.
+                   ;; trigger CI rebuild
                    (matchstr (file-name-nondirectory path))
                    (cands
                     (cond


### PR DESCRIPTION
Check for tramp path and only prevent refresh for those, this way history behaviour is more consistent with other commands (where the candidate list updates when going through history) and a message can be shown for the particular case of a tramp path in history so one can manually trigger the refresh in that case.
