### PR TITLE
Don't auto reset scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,8 @@ The format is based on [Keep a Changelog].
   would throw an error, which has been fixed ([#347], [#348]).
 * When `auto-hscroll-mode` was set to `current-line` prompts which
   exceeded the frame width would introduce constant back and forth
-  scrolling issues, which has been fixed ([#344], [#345]).
+  scrolling issues, which has been fixed ([#344], [#345], [#374]).
+  Currently there is still a cursor display issue on initial input.
 * `selectrum-select-from-history` set variables
   `selectrum-should-sort-p`, `selectrum-candidate-inserted-hook`,
   `selectrum-candidate-selected-hook` and

--- a/selectrum.el
+++ b/selectrum.el
@@ -723,9 +723,6 @@ the update."
     (goto-char (max (point) (minibuffer-prompt-end)))
     ;; For some reason this resets and thus can't be set in setup hook.
     (setq-local truncate-lines t)
-    ;; Esnure minibuffer window resets any scroll, for example history
-    ;; commands can increase scroll but fail to reset it.
-    (set-window-hscroll (active-minibuffer-window) 0)
     (let ((inhibit-read-only t)
           ;; Don't record undo information while messing with the
           ;; minibuffer, as per


### PR DESCRIPTION
This has some bad side effects for editing with long prompts, see #345.
