### PR TITLE
Improve selection behaviour for history commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog].
   required which helps when the element isn't a member of the
   candidate set and also fixes a problem with file completions when
   the element is a directory. Before the first file in that directory
-  would be selected ([#323], [#324], [#341], [#346]).
+  would be selected ([#323], [#324], [#341], [#346], [#380]).
 * Improved exit behaviour of `selectrum-select-current-candidate`. The
   commands gives feedback now when match is required and submission
   not possible. Also it allows submission of the prompt when a match
@@ -270,6 +270,7 @@ The format is based on [Keep a Changelog].
 [#377]: https://github.com/raxod502/selectrum/pull/377
 [#378]: https://github.com/raxod502/selectrum/pull/378
 [#379]: https://github.com/raxod502/selectrum/pull/379
+[#380]: https://github.com/raxod502/selectrum/pull/380
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,12 +53,10 @@ The format is based on [Keep a Changelog].
   [#365], [#367], [#368], [#372]).
 * In file completions the prompt will also be selected when a match is
   required and the path exists ([#357]).
-* With commands `next-history-element` and `previous-history-element`
-  the inserted history element will get selected when a match isn't
-  required which helps when the element isn't a member of the
-  candidate set and also fixes a problem with file completions when
-  the element is a directory. Before the first file in that directory
-  would be selected ([#323], [#324], [#341], [#346], [#380]).
+* Improved selection behaviour for history commands. When using
+  `next-history-element`, `previous-history-element` or isearch for
+  history browsing the inserted history element will get selected when
+  a match isn't required ([#323], [#324], [#341], [#346], [#380]).
 * Improved exit behaviour of `selectrum-select-current-candidate`. The
   commands gives feedback now when match is required and submission
   not possible. Also it allows submission of the prompt when a match

--- a/selectrum.el
+++ b/selectrum.el
@@ -822,8 +822,12 @@ the update."
                            (equal selectrum--default-candidate
                                   (minibuffer-contents)))
                       (and (not (= (minibuffer-prompt-end) (point-max)))
-                           (and minibuffer-history-position
-                                (not (zerop minibuffer-history-position)))
+                           (or (and minibuffer-history-position
+                                    (not (zerop minibuffer-history-position))
+                                    isearch-mode)
+                               (memq this-command
+                                     '(next-history-element
+                                       previous-history-element)))
                            (or (not selectrum--match-required-p)
                                (selectrum--at-existing-prompt-path-p))))
                   -1)


### PR DESCRIPTION
When history position is non-zero and one does provide input it is expected the first match gets selected, also when using isearch for searching the history the currently matched prompt should be selected.
