### PR TITLE
Improve scrolling for long prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,8 @@ The format is based on [Keep a Changelog].
   the available window width. When `auto-hscroll-mode` was set to
   `current-line` it would introduce constant back and forth scrolling
   issues and other values also wouldn't allow to use such a prompt
-  correctly ([#344], [#345], [#374], [#375], [#377], [#378], [#379]).
+  correctly ([#344], [#345], [#374], [#375], [#377], [#378], [#379],
+  [#381]).
 * `selectrum-select-from-history` set variables
   `selectrum-should-sort-p`, `selectrum-candidate-inserted-hook`,
   `selectrum-candidate-selected-hook` and
@@ -269,6 +270,7 @@ The format is based on [Keep a Changelog].
 [#378]: https://github.com/raxod502/selectrum/pull/378
 [#379]: https://github.com/raxod502/selectrum/pull/379
 [#380]: https://github.com/raxod502/selectrum/pull/380
+[#381]: https://github.com/raxod502/selectrum/pull/381
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -723,9 +723,9 @@ the update."
     (goto-char (max (point) (minibuffer-prompt-end)))
     ;; Scroll the minibuffer when current prompt exceeds window width.
     (let* ((width (window-width)))
-      (if (< (point) (- width (/ width 4)))
+      (if (< (point) (- width (/ width 3)))
           (set-window-hscroll nil 0)
-        (set-window-hscroll nil (- (point) (* 3 (/ width 4))))))
+        (set-window-hscroll nil (- (point) (/ width 3)))))
     ;; For some reason this resets and thus can't be set in setup hook.
     (setq-local truncate-lines t)
     (let ((inhibit-read-only t)

--- a/selectrum.el
+++ b/selectrum.el
@@ -723,9 +723,9 @@ the update."
     (goto-char (max (point) (minibuffer-prompt-end)))
     ;; Scroll the minibuffer when current prompt exceeds window width.
     (let* ((width (window-width)))
-      (if (< (point) (max (- width (/ width 4)) 1))
+      (if (< (point) (- width (/ width 4)))
           (set-window-hscroll nil 0)
-        (set-window-hscroll nil (- (point) (/ width 4)))))
+        (set-window-hscroll nil (- (point) (* 3 (/ width 4))))))
     ;; For some reason this resets and thus can't be set in setup hook.
     (setq-local truncate-lines t)
     (let ((inhibit-read-only t)


### PR DESCRIPTION
Change scroll position of prompt to keep position nearer to the start of the window where the candidates are displayed.