### PR TITLE
Honor completion-category-defaults and completion-category-overrides

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -154,7 +154,10 @@ frame you can use the provided action function
 Uses `completion-styles'."
   (nconc
    (completion-all-completions
-    input candidates nil (length input))
+    input candidates nil (length input)
+    (completion-metadata input
+                         minibuffer-completion-table
+                         minibuffer-completion-predicate))
    nil))
 
 (defcustom selectrum-refine-candidates-function


### PR DESCRIPTION
This is how the minibuffer normally filters candidates.

It looks like the `partial-completion` doesn't work with Selectrum, but if some day that gets fixed, it would be useful to choose a special completion style for files. Another possible interesting case would be the `consult-location` category, where I personally would like to use a "semi-flex" style that basically replaces spaces by `.*?`

Now, with that said, I would like to embed a basic Emacs question here: isn't it a bit strange/inflexible that the minibuffer merges `completion-styles` with the styles stipulated in `completion-category-defauts/overrides` (cf. `completion--styles` function)? I think it be useful if the merging didn't happen when the appropriate `styles` entry of `completion-category-overrides` ends with nil.