### PR TITLE
Improve env var completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ The format is based on [Keep a Changelog].
 
 ### Enhancements
 * You can now complete environment variables in file completions by
-  typing a "$" after a "/" ([#386]).
+  typing a "$" after a "/" ([#386], [#389]).
 * The `selectrum-select-from-history` command has been improved. You
   can now insert a history item into the previous session using your
   default binding for `selectrum-insert-current-candidate`. To submit
@@ -274,6 +274,7 @@ The format is based on [Keep a Changelog].
 [#380]: https://github.com/raxod502/selectrum/pull/380
 [#381]: https://github.com/raxod502/selectrum/pull/381
 [#386]: https://github.com/raxod502/selectrum/pull/386
+[#389]: https://github.com/raxod502/selectrum/pull/389
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1988,6 +1988,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
   (let* ((last-dir nil)
          (msg "Press \\[selectrum-insert-current-candidate] to refresh")
          (sortf nil)
+         (env-completion nil)
          (coll
           (lambda (input)
             (let* (;; Full path of input dir (might include shadowed parts).
@@ -2009,6 +2010,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                         (minibuffer-message
                          (substitute-command-keys msg))))
                      (env
+                      (setq env-completion t)
                       (setq matchstr (substring matchstr 1))
                       (cl-loop for var in (funcall collection env predicate t)
                                for val = (getenv var)
@@ -2020,6 +2022,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                 'selectrum-candidate-display-right-margin
                                 val)))
                      ((and (equal last-dir dir)
+                           (not env-completion)
                            (not selectrum--refresh-next-file-completion)
                            (not (and minibuffer-history-position
                                      (zerop minibuffer-history-position)
@@ -2030,6 +2033,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                   #'identity)
                       selectrum--preprocessed-candidates)
                      (t
+                      (setq env-completion nil)
                       (setq-local selectrum--refresh-next-file-completion nil)
                       (setq-local selectrum-preprocess-candidates-function
                                   sortf)


### PR DESCRIPTION
Follow up to #386, don't use cache for env completions, so when deleting the $ sign the files are shown again.
