### PR TITLE
Support partial-completion for files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,12 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
-* If an input path in file completions does not exist, the candidates
-  are now automatically searched by interpreting the input as an
-  partial-completion style input pattern. For tramp paths this has to
-  be triggered manually using `selectrum-insert-current-candidate` to
-  avoid possible speed problems ([#390]).
+* If the directory of the input path in file completions does not
+  exist, the candidates are now automatically gathered by interpreting
+  the input as an partial-completion style input pattern. For tramp
+  paths this has to be triggered manually using
+  `selectrum-insert-current-candidate` to avoid possible speed
+  problems ([#390]).
 * You can now complete environment variables in file completions by
   typing a "$" after a "/" ([#386], [#389]).
 * The `selectrum-select-from-history` command has been improved. You

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,7 @@ The format is based on [Keep a Changelog].
 [#381]: https://github.com/raxod502/selectrum/pull/381
 [#386]: https://github.com/raxod502/selectrum/pull/386
 [#389]: https://github.com/raxod502/selectrum/pull/389
+[#390]: https://github.com/raxod502/selectrum/pull/390
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* If an input path in file completions does not exist, the candidates
+  are now automatically searched by interpreting the input as an
+  partial-completion style input pattern. For tramp paths this has to
+  be triggered manually using `selectrum-insert-current-candidate` to
+  avoid possible speed problems ([#390]).
 * You can now complete environment variables in file completions by
   typing a "$" after a "/" ([#386], [#389]).
 * The `selectrum-select-from-history` command has been improved. You

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,13 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
-* If the directory of the input path in file completions does not
-  exist, the candidates are now automatically gathered by interpreting
-  the input as an partial-completion style input pattern. For tramp
-  paths this has to be triggered manually using
-  `selectrum-insert-current-candidate` to avoid possible speed
-  problems ([#390]).
+* In file completions where the directory path of the input does not
+  exist, the candidates are automatically gathered by interpreting the
+  input as an partial-completion style input pattern (see
+  `completion-styles-alist`). For example the input "/us/l/bi/" would
+  give results for "/usr/local/bin/". With tramp paths this has to be
+  triggered manually using `selectrum-insert-current-candidate` to
+  avoid possible speed problems ([#390]).
 * You can now complete environment variables in file completions by
   typing a "$" after a "/" ([#386], [#389]).
 * The `selectrum-select-from-history` command has been improved. You

--- a/selectrum.el
+++ b/selectrum.el
@@ -1571,7 +1571,7 @@ refresh."
           (setq selectrum--previous-input-string nil)
           (when minibuffer-history-position
             (when minibuffer-completing-file-name
-              ;; Choosing a history item needs to trigger a refresh.
+              ;; Force a refresh for files.
               (setq-local selectrum--refresh-next-file-completion t))
             (selectrum--reset-minibuffer-history-state)))
       (unless completion-fail-discreetly

--- a/selectrum.el
+++ b/selectrum.el
@@ -1987,7 +1987,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
   (let* ((last-dir nil)
          (msg "Press \\[selectrum-insert-current-candidate] to refresh")
          (sortf nil)
-         (env-completion nil)
+         (is-env-completion nil)
          (coll
           (lambda (input)
             (let* (;; Full path of input dir might include shadowed parts.
@@ -2009,7 +2009,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                         (minibuffer-message
                          (substitute-command-keys msg))))
                      ((string-prefix-p "$" matchstr)
-                      (setq env-completion t)
+                      (setq is-env-completion t)
                       (setq matchstr (substring matchstr 1))
                       (cl-loop for var in
                                (funcall
@@ -2023,7 +2023,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                 'selectrum-candidate-display-right-margin
                                 val)))
                      ((and (equal last-dir dir)
-                           (not env-completion)
+                           (not is-env-completion)
                            (not selectrum--refresh-next-file-completion)
                            (not (and minibuffer-history-position
                                      (zerop minibuffer-history-position)
@@ -2040,7 +2040,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                           (prog1 nil
                             (minibuffer-message
                              (substitute-command-keys msg)))
-                        (setq env-completion nil)
+                        (setq is-env-completion nil)
                         (setq-local selectrum--refresh-next-file-completion
                                     nil)
                         (setq-local selectrum-preprocess-candidates-function
@@ -2062,7 +2062,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                        match 'selectrum-candidate-full
                                        (concat prefix match suffix))))))))
                      (t
-                      (setq env-completion nil)
+                      (setq is-env-completion nil)
                       (setq-local selectrum--refresh-next-file-completion nil)
                       (setq-local selectrum-preprocess-candidates-function
                                   sortf)

--- a/selectrum.el
+++ b/selectrum.el
@@ -2033,7 +2033,8 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                       (setq-local selectrum-preprocess-candidates-function
                                   #'identity)
                       selectrum--preprocessed-candidates)
-                     ((not (file-exists-p dir))
+                     ((and (not (string-empty-p dir))
+                           (not (file-exists-p dir)))
                       (if (and is-tramp-path
                                (not selectrum--refresh-next-file-completion))
                           (prog1 nil

--- a/selectrum.el
+++ b/selectrum.el
@@ -2047,20 +2047,19 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                     sortf)
                         (pcase-let ((`(,pattern ,all ,prefix ,suffix)
                                      (completion-pcm--find-all-completions
-                                      input collection predicate
-                                      (length input))))
+                                      path collection predicate
+                                      (length path))))
                           (when all
-                            (cl-delete-if
-                             (lambda (path)
-                               (or (string-suffix-p "./" path)
-                                   (string-suffix-p "../" path)))
-                             (cl-loop for match in
-                                      (completion-pcm--hilit-commonality
-                                       pattern all)
-                                      collect
-                                      (propertize
-                                       match 'selectrum-candidate-full
-                                       (concat prefix match suffix))))))))
+                            (cl-loop for match in
+                                     (completion-pcm--hilit-commonality
+                                      pattern all)
+                                     unless (string-suffix-p "../" match)
+                                     collect
+                                     (let ((path (string-remove-suffix
+                                                  "./" match)))
+                                       (propertize
+                                        path 'selectrum-candidate-full
+                                        (concat prefix path suffix))))))))
                      (t
                       (setq is-env-completion nil)
                       (setq-local selectrum--refresh-next-file-completion nil)

--- a/selectrum.el
+++ b/selectrum.el
@@ -2040,8 +2040,11 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                           (prog1 nil
                             (minibuffer-message
                              (substitute-command-keys msg)))
+                        (setq env-completion nil)
                         (setq-local selectrum--refresh-next-file-completion
                                     nil)
+                        (setq-local selectrum-preprocess-candidates-function
+                                  sortf)
                         (pcase-let ((`(,pattern ,all ,prefix ,suffix)
                                      (completion-pcm--find-all-completions
                                       input collection predicate

--- a/selectrum.el
+++ b/selectrum.el
@@ -2040,15 +2040,15 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                           (prog1 nil
                             (minibuffer-message
                              (substitute-command-keys msg)))
-                        (setq is-env-completion nil)
-                        (setq-local selectrum--refresh-next-file-completion
-                                    nil)
-                        (setq-local selectrum-preprocess-candidates-function
-                                    sortf)
                         (pcase-let ((`(,pattern ,all ,prefix ,suffix)
                                      (completion-pcm--find-all-completions
                                       path collection predicate
                                       (length path))))
+                          (setq is-env-completion nil)
+                          (setq-local selectrum--refresh-next-file-completion
+                                      nil)
+                          (setq-local selectrum-preprocess-candidates-function
+                                      sortf)
                           (when all
                             (cl-loop for match in
                                      (completion-pcm--hilit-commonality

--- a/selectrum.el
+++ b/selectrum.el
@@ -2082,16 +2082,16 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
     (minibuffer-with-setup-hook
         ;; The hook needs to run late as `read-file-name-default' sets
         ;; its own syntax table in `minibuffer-with-setup-hook'.
-        (lambda ()
-          ;; Pickup the value as configured for current
-          ;; session.
-          (setq sortf selectrum-preprocess-candidates-function)
-          ;; Ensure the variable is also set when
-          ;; selectrum--completing-read-file-name is called
-          ;; directly.
-          (setq-local minibuffer-completing-file-name t)
-          (set-syntax-table
-           selectrum--minibuffer-local-filename-syntax))
+        (:append (lambda ()
+                   ;; Pickup the value as configured for current
+                   ;; session.
+                   (setq sortf selectrum-preprocess-candidates-function)
+                   ;; Ensure the variable is also set when
+                   ;; selectrum--completing-read-file-name is called
+                   ;; directly.
+                   (setq-local minibuffer-completing-file-name t)
+                   (set-syntax-table
+                    selectrum--minibuffer-local-filename-syntax)))
       (selectrum-read
        prompt coll
        :default-candidate (or (car-safe def) def)

--- a/selectrum.el
+++ b/selectrum.el
@@ -2039,7 +2039,8 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                           (prog1 nil
                             (minibuffer-message
                              (substitute-command-keys msg)))
-                        (setq-local selectrum--refresh-next-file-completion nil)
+                        (setq-local selectrum--refresh-next-file-completion
+                                    nil)
                         (pcase-let ((`(,pattern ,all ,prefix ,suffix)
                                      (completion-pcm--find-all-completions
                                       input collection predicate

--- a/selectrum.el
+++ b/selectrum.el
@@ -2044,7 +2044,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                         (setq-local selectrum--refresh-next-file-completion
                                     nil)
                         (setq-local selectrum-preprocess-candidates-function
-                                  sortf)
+                                    sortf)
                         (pcase-let ((`(,pattern ,all ,prefix ,suffix)
                                      (completion-pcm--find-all-completions
                                       input collection predicate


### PR DESCRIPTION
See #385, this tries to find matches via partial completion by default when the input directory doesn't exist. Used this way it isn't used as a completion-style but rather as a useful fallback to gather candidates which only triggers when it makes sense.
