### PR TITLE
Improve partial-style file completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog].
   `completion-styles-alist`). For example the input "/us/l/bi/" would
   give results for "/usr/local/bin/". With tramp paths this has to be
   triggered manually using `selectrum-insert-current-candidate` to
-  avoid possible speed problems ([#390]).
+  avoid possible speed problems ([#390], [#393]).
 * You can now complete environment variables in file completions by
   typing a "$" after a "/" ([#386], [#389]).
 * The `selectrum-select-from-history` command has been improved. You
@@ -283,6 +283,7 @@ The format is based on [Keep a Changelog].
 [#386]: https://github.com/raxod502/selectrum/pull/386
 [#389]: https://github.com/raxod502/selectrum/pull/389
 [#390]: https://github.com/raxod502/selectrum/pull/390
+[#393]: https://github.com/raxod502/selectrum/pull/393
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -2034,6 +2034,8 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                    (matchstr (file-name-nondirectory path))
                    (cands
                     (cond
+                     ;; Guard against automatic tramp connections when
+                     ;; browsing history.
                      ((and minibuffer-history-position
                            (not (zerop minibuffer-history-position))
                            (not selectrum--refresh-next-file-completion)
@@ -2041,6 +2043,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                       (prog1 nil
                         (minibuffer-message
                          (substitute-command-keys msg))))
+                     ;; Env var completion.
                      ((string-prefix-p "$" matchstr)
                       (setq is-env-completion t)
                       (setq matchstr (substring matchstr 1))
@@ -2055,6 +2058,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                 (concat dir val)
                                 'selectrum-candidate-display-right-margin
                                 val)))
+                     ;; Use cache.
                      ((and (equal last-dir dir)
                            (not is-env-completion)
                            (not selectrum--refresh-next-file-completion)
@@ -2066,6 +2070,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                       (setq-local selectrum-preprocess-candidates-function
                                   #'identity)
                       selectrum--preprocessed-candidates)
+                     ;; Use partial completion.
                      ((and (not (string-empty-p dir))
                            (not (file-exists-p dir)))
                       (if (and is-remote-path
@@ -2096,6 +2101,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                         'selectrum-candidate-full
                                         full
                                         'selectrum--partial prefix)))))))
+                     ;; Compute from file table.
                      (t
                       (setq is-env-completion nil)
                       (setq-local selectrum--refresh-next-file-completion nil)

--- a/selectrum.el
+++ b/selectrum.el
@@ -801,11 +801,11 @@ the update."
         ;; Do refinement.
         (let* ((cands selectrum--preprocessed-candidates)
                (completion-styles-alist
+                ;; Remap partial-style for file completions
+                ;; computed from partial input.
                 (if (and cands
                          (get-text-property
                           0 'selectrum--partial (car cands)))
-                    ;; Remap partial-style for file completions coming from
-                    ;; partial input path.
                     (cons '(partial-completion
                             ignore
                             selectrum--completion-pcm-all-completions

--- a/selectrum.el
+++ b/selectrum.el
@@ -808,8 +808,7 @@ the update."
                           0 'selectrum--partial (car cands)))
                     (cons '(partial-completion
                             ignore
-                            selectrum--completion-pcm-all-completions
-                            "")
+                            selectrum--completion-pcm-all-completions "")
                           completion-styles-alist)
                   completion-styles-alist)))
           (setq selectrum--refined-candidates
@@ -2096,11 +2095,11 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
                                      (let* ((path (string-remove-suffix
                                                    "./" match))
                                             (full (concat prefix path suffix)))
-                                       (propertize
-                                        path
-                                        'selectrum-candidate-full
-                                        full
-                                        'selectrum--partial prefix)))))))
+                                       (propertize path
+                                                   'selectrum-candidate-full
+                                                   full
+                                                   'selectrum--partial
+                                                   prefix)))))))
                      ;; Compute from file table.
                      (t
                       (setq is-env-completion nil)

--- a/selectrum.el
+++ b/selectrum.el
@@ -182,8 +182,8 @@ For STRING, CANDS, PRED and POINT see
                                         'selectrum--partial cand)
                          collect (propertize partial
                                              'selectrum-candidate-full
-                                             partial))))
-  (completion-pcm-all-completions string cands pred point))
+                                             partial)))
+    (completion-pcm-all-completions string cands pred point)))
 
 (defcustom selectrum-refine-candidates-function
   #'selectrum-refine-candidates-using-completions-styles

--- a/selectrum.el
+++ b/selectrum.el
@@ -176,8 +176,8 @@ For STRING, CANDS, PRED and POINT see
                                        (get-text-property
                                         0 'selectrum-candidate-full cand))))
            (res (nconc (completion-pcm-all-completions
-                                   string cands pred point)
-                         nil)))
+                        string cands pred point)
+                       nil)))
       (cl-loop for cand in res
                collect (substring cand len)))))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -2024,7 +2024,7 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
          (is-env-completion nil)
          (coll
           (lambda (input)
-            (let* (;; Full path of input dir might include shadowed parts.
+            (let* (;; Path of input dir might include shadowed paths.
                    (path (substitute-in-file-name input))
                    (is-remote-path
                     (file-remote-p path))

--- a/selectrum.el
+++ b/selectrum.el
@@ -174,7 +174,7 @@ Uses `completion-styles'."
 For STRING, CANDS, PRED and POINT see
 `completion-pcm-all-completions'."
   (when cands
-    (setq string (minibuffer-contents))
+    (setq string (substitute-in-file-name (minibuffer-contents)))
     (setq point (length string))
     (setq cands (cl-loop for cand in cands
                          for partial = (get-text-property


### PR DESCRIPTION
#390 introduced partial completions for the input path, afterwards one can continue to filter these using the configured filter function / completion-styles. In case one would like to use the partial-completion style on these results this still wouldn't work as reported by @mathrick in #82. To fix this I remapped the partial-style for the partial file completion case using `completion-styles-alist`. This isn't nice but seems like the best way to handle partial-completion style for files from Selectrum side.