### PR TITLE
Ensure enabled recursive minibuffers for special commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* When `enable-recursive-minibuffers` is nil Selectrum will
+  temporarily let bind it to a non-nil value for commands which
+  require it ([#100], [#397]).
 * In file completions where the directory path of the input does not
   exist, the candidates are automatically gathered by interpreting the
   input as an partial-completion style input pattern (see
@@ -216,6 +219,7 @@ The format is based on [Keep a Changelog].
   property in file completions were overwritten for directories and
   not displayed, which has been fixed ([#256], [#255]).
 
+[#100]: https://github.com/raxod502/selectrum/issues/100
 [#194]: https://github.com/raxod502/selectrum/issues/194
 [#200]: https://github.com/raxod502/selectrum/pull/200
 [#208]: https://github.com/raxod502/selectrum/pull/208
@@ -307,6 +311,7 @@ The format is based on [Keep a Changelog].
 [#389]: https://github.com/raxod502/selectrum/pull/389
 [#390]: https://github.com/raxod502/selectrum/pull/390
 [#393]: https://github.com/raxod502/selectrum/pull/393
+[#397]: https://github.com/raxod502/selectrum/pull/397
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,10 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
-* When `enable-recursive-minibuffers` is nil Selectrum will
-  temporarily let bind it to a non-nil value for commands which
-  require it ([#100], [#397]).
+* Selectrum will allow recursive sessions for
+  `selectrum-completion-in-region` and `selectrum-select-from-history`
+  so these commands work even if `enable-recursive-minibuffers` is not
+  set by the user ([#100], [#397]).
 * In file completions where the directory path of the input does not
   exist, the candidates are automatically gathered by interpreting the
   input as an partial-completion style input pattern (see

--- a/selectrum.el
+++ b/selectrum.el
@@ -1898,7 +1898,8 @@ history item and exit use `selectrum-select-current-candidate'."
                   (setq-local selectrum-should-sort-p nil)
                   (setq-local selectrum-candidate-inserted-hook nil)
                   (setq-local selectrum-candidate-selected-hook nil)
-                  (use-local-map (make-composed-keymap nil (current-local-map)))
+                  (use-local-map
+                   (make-composed-keymap nil (current-local-map)))
                   (define-key (current-local-map)
                     [remap selectrum-insert-current-candidate]
                     'selectrum--insert-history)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1891,28 +1891,28 @@ history item and exit use `selectrum-select-current-candidate'."
   (let ((history (symbol-value minibuffer-history-variable)))
     (when (eq history t)
       (user-error "No history is recorded for this command"))
-    (let ((result
-           (minibuffer-with-setup-hook
-               (lambda ()
-                 (setq-local enable-recursive-minibuffers t)
-                 (setq-local selectrum-should-sort-p nil)
-                 (setq-local selectrum-candidate-inserted-hook nil)
-                 (setq-local selectrum-candidate-selected-hook nil)
-                 (use-local-map (make-composed-keymap nil (current-local-map)))
-                 (define-key (current-local-map)
-                   [remap selectrum-insert-current-candidate]
-                   'selectrum--insert-history)
-                 (let ((inhibit-read-only t))
-                   (goto-char (or (search-backward ":" nil t)
-                                  (1- (minibuffer-prompt-end))))
-                   (insert
-                    (apply
-                     #'propertize
-                     " [history]"
-                     (text-properties-at (point))))))
-             (catch 'selectrum-insert-action
-               (completing-read
-                (minibuffer-prompt) history nil t nil t)))))
+    (let* ((enable-recursive-minibuffers t)
+           (result
+            (minibuffer-with-setup-hook
+                (lambda ()
+                  (setq-local selectrum-should-sort-p nil)
+                  (setq-local selectrum-candidate-inserted-hook nil)
+                  (setq-local selectrum-candidate-selected-hook nil)
+                  (use-local-map (make-composed-keymap nil (current-local-map)))
+                  (define-key (current-local-map)
+                    [remap selectrum-insert-current-candidate]
+                    'selectrum--insert-history)
+                  (let ((inhibit-read-only t))
+                    (goto-char (or (search-backward ":" nil t)
+                                   (1- (minibuffer-prompt-end))))
+                    (insert
+                     (apply
+                      #'propertize
+                      " [history]"
+                      (text-properties-at (point))))))
+              (catch 'selectrum-insert-action
+                (completing-read
+                 (minibuffer-prompt) history nil t nil t)))))
       (if (get-text-property 0 'selectum--insert result)
           (progn
             (delete-minibuffer-contents)
@@ -2172,7 +2172,8 @@ the prompt."
   "Complete in-buffer text using a list of candidates.
 Can be used as `completion-in-region-function'. For START, END,
 COLLECTION, and PREDICATE, see `completion-in-region'."
-  (let* ((input (buffer-substring-no-properties start end))
+  (let* ((enable-recursive-minibuffers t)
+         (input (buffer-substring-no-properties start end))
          (meta (completion-metadata input collection predicate))
          (category (completion-metadata-get meta 'category))
          (bound (pcase category


### PR DESCRIPTION
See #100, commands like completion-in-region should work out of the box regardless of the `enable-recursive-minibuffers` setting. Let binding it in this cases is also what the built-in `describe-...` commands do.
