### PR TITLE
Accept a list for `default-filename` in `selectrum-read-file-name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,7 @@ The format is based on [Keep a Changelog].
 
 ### Bugs fixed
 * `selectrum-read-file-name` now accepts a list for `default-filename`
-  and behaves according to the original `read-file-name`
+  and behaves according to the original `read-file-name` ([#401]).
 * Selectrum did not set `minibuffer-default` for the current
   completion session, which has been fixed ([#350], [#352], [#354]).
 * When there were no candidates `selectrum-get-current-candidate`
@@ -327,6 +327,7 @@ The format is based on [Keep a Changelog].
 [#394]: https://github.com/raxod502/selectrum/pull/394
 [#397]: https://github.com/raxod502/selectrum/pull/397
 [#398]: https://github.com/raxod502/selectrum/pull/398
+[#401]: https://github.com/raxod502/selectrum/pull/401
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,8 @@ The format is based on [Keep a Changelog].
   can be configured as well ([#266], [#302], [#318], [#398]).
 
 ### Bugs fixed
+* `selectrum-read-file-name` now accepts a list for `default-filename`
+  and behaves according to the original `read-file-name`
 * Selectrum did not set `minibuffer-default` for the current
   completion session, which has been fixed ([#350], [#352], [#354]).
 * When there were no candidates `selectrum-get-current-candidate`

--- a/selectrum.el
+++ b/selectrum.el
@@ -2465,6 +2465,10 @@ For PROMPT, COLLECTION, PREDICATE, REQUIRE-MATCH, INITIAL-INPUT,
   "Read file name using Selectrum. Can be used as `read-file-name-function'.
 For PROMPT, DIR, DEFAULT-FILENAME, MUSTMATCH, INITIAL, and
 PREDICATE, see `read-file-name'."
+  (when (listp default-filename)
+    (setq default-filename
+          (cl-loop for elt in default-filename
+                   if (stringp elt) return elt)))
   (let* ((crf completing-read-function)
          ;; See <https://github.com/raxod502/selectrum/issues/61>.
          ;; When you invoke another `completing-read' command


### PR DESCRIPTION
The built-in function accepts a list as well as a string, in which case it picks the first string.

Fixes [#17](https://github.com/holomorph/transmission/issues/17) in [transmission](https://github.com/holomorph/transmission/).