### PR TITLE
Improve default handling for file completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,8 @@ The format is based on [Keep a Changelog].
   can be configured as well ([#266], [#302], [#318], [#398]).
 
 ### Bugs fixed
+* `selectrum-read-file-name` would error when passing a list for
+  `default-filename`, which has been fixed ([#401], [#402]).
 * Selectrum did not set `minibuffer-default` for the current
   completion session, which has been fixed ([#350], [#352], [#354]).
 * When there were no candidates `selectrum-get-current-candidate`
@@ -325,6 +327,8 @@ The format is based on [Keep a Changelog].
 [#394]: https://github.com/raxod502/selectrum/pull/394
 [#397]: https://github.com/raxod502/selectrum/pull/397
 [#398]: https://github.com/raxod502/selectrum/pull/398
+[#401]: https://github.com/raxod502/selectrum/pull/401
+[#402]: https://github.com/raxod502/selectrum/pull/402
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* The sorting of passed defaults for file completions has been
+  improved such that paths like "/home/user/default", "~/default" or a
+  relative passed default get sorted first when they exist within the
+  prompting directory ([#402]).
 * Tramp completions have been improved. You now get completion for
   tramp methods and hosts. If a connection hasn't been established yet
   and you are manually typing the path, a message is shown that you

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,8 +155,8 @@ The format is based on [Keep a Changelog].
   can be configured as well ([#266], [#302], [#318], [#398]).
 
 ### Bugs fixed
-* `selectrum-read-file-name` would error when passing a list for
-  `default-filename`, which has been fixed ([#401], [#402]).
+* Selectrum would error when providing a list as default value in file
+  completions, which has been fixed ([#401], [#402]).
 * Selectrum did not set `minibuffer-default` for the current
   completion session, which has been fixed ([#350], [#352], [#354]).
 * When there were no candidates `selectrum-get-current-candidate`

--- a/selectrum.el
+++ b/selectrum.el
@@ -2477,20 +2477,28 @@ PREDICATE, see `read-file-name'."
          (completing-read-function
           (lambda (&rest args)
             (setq completing-read-function crf)
-            (when (and default-filename
-                       ;; ./ should be omitted.
-                       (not (equal
-                             (expand-file-name default-filename)
-                             (expand-file-name default-directory))))
-              (setf (nth 6 args)        ; DEFAULT
-                    ;; Sort for directories needs any final
-                    ;; slash removed.
-                    (directory-file-name
-                     ;; The candidate should be sorted by it's
-                     ;; relative name.
-                     (file-relative-name default-filename
-                                         default-directory))))
-            (apply #'selectrum--completing-read-file-name args))))
+            (let ((default (if (consp default-filename)
+                               (car default-filename)
+                             default-filename)))
+              (when (and default
+                         ;; ./ should be omitted.
+                         (not (equal
+                               (expand-file-name default)
+                               (expand-file-name default-directory))))
+                (setq default
+                      ;; Sort for directories needs any final
+                      ;; slash removed.
+                      (directory-file-name
+                       ;; The candidate should be sorted by it's
+                       ;; relative name.
+                       (file-relative-name default
+                                           default-directory)))
+                (if (consp default-filename)
+                    (setcar default-filename default)
+                  (setq default-filename default))
+                ;; Change the passed DEFAULT arg.
+                (setf (nth 6 args) default-filename))
+              (apply #'selectrum--completing-read-file-name args)))))
     (read-file-name-default
      prompt dir
      ;; We don't pass default-candidate here to avoid that

--- a/selectrum.el
+++ b/selectrum.el
@@ -2480,21 +2480,25 @@ PREDICATE, see `read-file-name'."
             (let ((default (if (consp default-filename)
                                (car default-filename)
                              default-filename)))
-              (when (and default
-                         ;; ./ should be omitted.
-                         (not (equal
-                               (expand-file-name default)
-                               (expand-file-name default-directory))))
-                (setq default
-                      ;; The candidate should be sorted by it's
-                      ;; relative name.
-                      (file-relative-name default
-                                          default-directory))
+              ;; Get the default back for internal handling as it
+              ;; wasn't passed to `read-file-name-default'. See
+              ;; comment below.
+              (when default
+                (when (equal (file-name-directory
+                              (directory-file-name
+                               (expand-file-name
+                                default)))
+                             (file-name-directory
+                              (expand-file-name
+                               default-directory)))
+                  ;; Make the default sorted first by its relative name
+                  ;; when it is inside the prompting directory.
+                  (setq default
+                        (file-relative-name default default-directory)))
                 (if (consp default-filename)
                     (setcar default-filename default)
                   (setq default-filename default))
-                ;; Change the passed DEFAULT arg to make the default
-                ;; get sorted first.
+                ;; Adjust the DEFAULT arg.
                 (setf (nth 6 args) default-filename))
               (apply #'selectrum--completing-read-file-name args)))))
     (read-file-name-default

--- a/selectrum.el
+++ b/selectrum.el
@@ -2486,13 +2486,10 @@ PREDICATE, see `read-file-name'."
                                (expand-file-name default)
                                (expand-file-name default-directory))))
                 (setq default
-                      ;; Sort for directories needs any final
-                      ;; slash removed.
-                      (directory-file-name
-                       ;; The candidate should be sorted by it's
-                       ;; relative name.
-                       (file-relative-name default
-                                           default-directory)))
+                      ;; The candidate should be sorted by it's
+                      ;; relative name.
+                      (file-relative-name default
+                                          default-directory))
                 (if (consp default-filename)
                     (setcar default-filename default)
                   (setq default-filename default))

--- a/selectrum.el
+++ b/selectrum.el
@@ -2493,7 +2493,8 @@ PREDICATE, see `read-file-name'."
                 (if (consp default-filename)
                     (setcar default-filename default)
                   (setq default-filename default))
-                ;; Change the passed DEFAULT arg.
+                ;; Change the passed DEFAULT arg to make the default
+                ;; get sorted first.
                 (setf (nth 6 args) default-filename))
               (apply #'selectrum--completing-read-file-name args)))))
     (read-file-name-default


### PR DESCRIPTION
`selectrum-read-file-name` would error when passing a list for  `default-filename` as reported by @VojtechStep in #401 . Also we still had code which would remove the final slash for sorting the default first in file completions which wouldn't apply any more as dir candidates don't use an overlay any more to display the slash but contain it in their string now. 

I also improved the sorting so "/home/user/default" and "~/default" or a relative passed default get sorted first when they exist within the prompting directory. We still need to find a good way to indicate the default in file completions when that isn't the case, see #400.
