### PR TITLE
Fix file-name completion after ~//ssh:host:do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ The format is based on [Keep a Changelog].
   correcting typos before trying to establish a new connection. Lastly
   if tramp would error or you would quit from a password prompt
   Selectrum stopped working until you restarted the session, which has
-  been fixed ([#392], [#394], [#405]).
+  been fixed ([#392], [#394], [#405], [#408]).
 * Selectrum will allow recursive sessions for
   `selectrum-completion-in-region` and `selectrum-select-from-history`
   so these commands work even if `enable-recursive-minibuffers` is not
@@ -338,6 +338,7 @@ The format is based on [Keep a Changelog].
 [#403]: https://github.com/raxod502/selectrum/pull/403
 [#404]: https://github.com/raxod502/selectrum/pull/404
 [#405]: https://github.com/raxod502/selectrum/pull/405
+[#408]: https://github.com/raxod502/selectrum/pull/408
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -649,10 +649,12 @@ behavior."
         (if (and selectrum--current-candidate-index
                  (< selectrum--current-candidate-index 0))
             candidate
-          (let ((pathprefix (minibuffer-contents)))
-            (unless (file-directory-p (substitute-in-file-name pathprefix))
-              (setq pathprefix (or (file-name-directory pathprefix) "")))
-            (concat pathprefix candidate))))
+          (let* ((input (minibuffer-contents))
+                 (path (substitute-in-file-name input))
+                 (dirlen (length (file-name-directory path)))
+                 (prefixlen (car (completion--sifn-requote dirlen input)))
+                 (prefix (substring input 0 prefixlen)))
+            (concat prefix candidate))))
       candidate))
 
 (defun selectrum--get-candidate (index)


### PR DESCRIPTION
I don't know how I missed this one in #405.
Turns out that extracting the `~//ssh:host:` prefix out of `~//ssh:host:do` is
surprisingly tricky. Luckily `completion--sifn-requote` does basically just
that.
