### PR TITLE
Ensure pixelwise resize for minibuffer height update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
+* Depending on the used font and display settings like `line-spacing`
+  the minibuffer height could be slightly off so that the displayed
+  candidates wouldn't be completely visible, which has been fixed
+  ([#303], [#414]).
 * The sorting of passed defaults for file completions has been
   improved such that paths like "/home/user/default", "~/default" or a
   relative passed default get sorted first when they exist within the
@@ -279,6 +283,7 @@ The format is based on [Keep a Changelog].
 [#295]: https://github.com/raxod502/selectrum/pull/295
 [#296]: https://github.com/raxod502/selectrum/pull/296
 [#302]: https://github.com/raxod502/selectrum/pull/302
+[#303]: https://github.com/raxod502/selectrum/issues/303
 [#305]: https://github.com/raxod502/selectrum/pull/305
 [#306]: https://github.com/raxod502/selectrum/issues/306
 [#307]: https://github.com/raxod502/selectrum/pull/307
@@ -348,6 +353,7 @@ The format is based on [Keep a Changelog].
 [#408]: https://github.com/raxod502/selectrum/pull/408
 [#411]: https://github.com/raxod502/selectrum/issues/411
 [#413]: https://github.com/raxod502/selectrum/pull/413
+[#414]: https://github.com/raxod502/selectrum/pull/414
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -1286,7 +1286,8 @@ Also works for frames if WINDOW is the root window of its frame."
   "Update window height of minibuffer WINDOW.
 WINDOW will be updated to fit its content vertically."
   (let ((dheight (cdr (window-text-pixel-size window)))
-        (wheight (window-pixel-height window)))
+        (wheight (window-pixel-height window))
+        (window-resize-pixelwise t))
     (window-resize
      window (- dheight wheight) nil nil 'pixelwise)))
 


### PR DESCRIPTION
The height wouldn't correctly update in some cases if `window-resize-pixelwise` wasn't set during `selectrum--update-minibuffer-height`, see #303. 
