### PR TITLE
Don't sort for selectrum-completion-in-region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,8 @@ The format is based on [Keep a Changelog].
 * Default settings of `selectrum-multiline-display-settings` have been
   improved. There is now also a displayed line count by default which
   can be configured as well ([#266], [#302], [#318], [#398]).
+* `selectrum-completion-in-region` doesn't sort now as the
+  `completon-at-point-function` backend may does its own sorting.
 
 ### Bugs fixed
 * Candidate parts which used the `display` property wouldn't be

--- a/selectrum.el
+++ b/selectrum.el
@@ -2224,7 +2224,8 @@ the prompt."
   "Complete in-buffer text using a list of candidates.
 Can be used as `completion-in-region-function'. For START, END,
 COLLECTION, and PREDICATE, see `completion-in-region'."
-  (let* ((enable-recursive-minibuffers t)
+  (let* ((selectrum-should-sort-p nil)
+         (enable-recursive-minibuffers t)
          (input (buffer-substring-no-properties start end))
          (meta (completion-metadata input collection predicate))
          (category (completion-metadata-get meta 'category))


### PR DESCRIPTION
The `completion-at-point-function` backend may does its own sorting.