### PR TITLE
Undo prepend of background for selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,11 +54,6 @@ The format is based on [Keep a Changelog].
   default is t) ([#261]).
 
 ### Enhancements
-* The background of `selectrum-current-candidate` face gets prepended
-  so the selection stays visible for candidates with `:background`
-  property. This change is only noticeable in Emacs versions >= 27 as
-  for previous versions `selectrum-current-candidate` face gets
-  prepended by default ([#425], [#431]).
 * The default value of `selectrum-extend-current-candidate-highlight`
   has been changed to `auto` which will automatically extend the
   highlighting if the session uses annotations ([#427], [#430]).
@@ -371,11 +366,9 @@ The format is based on [Keep a Changelog].
 [#414]: https://github.com/raxod502/selectrum/pull/414
 [#420]: https://github.com/raxod502/selectrum/issues/420
 [#424]: https://github.com/raxod502/selectrum/issues/424
-[#425]: https://github.com/raxod502/selectrum/issues/425
 [#421]: https://github.com/raxod502/selectrum/pull/421
 [#427]: https://github.com/raxod502/selectrum/issues/427
 [#430]: https://github.com/raxod502/selectrum/pull/430
-[#431]: https://github.com/raxod502/selectrum/pull/431
 [#432]: https://github.com/raxod502/selectrum/pull/432
 
 ## 3.0 (released 2020-10-20)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1525,12 +1525,7 @@ specs."
       (add-face-text-property
        0 (length str)
        face
-       'append str)
-      ;; Prepend the background to ensure selection is always visible.
-      (add-face-text-property
-       0 (length str)
-       `(:background ,(face-attribute face :background nil 'default))
-       nil str))
+       'append str))
     str))
 
 (defun selectrum--affixate (fun candidates)


### PR DESCRIPTION
If the theme uses backgrounds to highlight matches they wouldn't be visible on the selection.The popular zenburn and modus themes both do this so it seems safer not going that route for now until there is abetter fix for #425 

