### PR TITLE
Add selectrum-default-value-format customizable variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ The format is based on [Keep a Changelog].
 * The user option `selectrum-complete-in-buffer` can be used to
   control whether Selectrum should handle in buffer completion (the
   default is t) ([#261]).
+* The user option `selectrum-default-value-format` can be used
+  to specify the formatting of the default value indicator ([#445]).
 
 ### Enhancements
 * The variable `selectrum-should-sort-p` and `selectrum-active-p` have
@@ -386,6 +388,7 @@ The format is based on [Keep a Changelog].
 [#439]: https://github.com/raxod502/selectrum/pull/439
 [#440]: https://github.com/raxod502/selectrum/pull/440
 [#444]: https://github.com/raxod502/selectrum/pull/444
+[#445]: https://github.com/raxod502/selectrum/pull/445
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/selectrum.el
+++ b/selectrum.el
@@ -80,6 +80,10 @@ parts of the input."
   'selectrum-should-sort
   "3.0")
 
+(defcustom selectrum-default-value-format " [default: %s]"
+  "Format string for the default value in the minibuffer."
+  :type '(choice (const nil) string))
+
 (defcustom selectrum-should-sort t
   "Non-nil if preprocessing function should sort.
 This should be respected by user functions for optimal results."
@@ -1255,7 +1259,8 @@ the update."
                        (erase-buffer)
                        (current-buffer)))
              (default
-               (when (and (= (minibuffer-prompt-end) (point-max))
+               (when (and selectrum-default-value-format
+                          (= (minibuffer-prompt-end) (point-max))
                           (or
                            (and selectrum--current-candidate-index
                                 (< selectrum--current-candidate-index 0))
@@ -1265,22 +1270,16 @@ the update."
                                 (not minibuffer-completing-file-name)
                                 (not (member selectrum--default-candidate
                                              selectrum--refined-candidates)))))
-                 (format " %s %s%s"
+                 (format (propertize selectrum-default-value-format
+                                     'face 'minibuffer-prompt)
                          (propertize
-                          "[default value:"
-                          'face 'minibuffer-prompt)
-                         (propertize
-                          (or (and selectrum--default-candidate
-                                   (substring-no-properties
-                                    selectrum--default-candidate))
-                              "\"\"")
+                          (or selectrum--default-candidate "\"\"")
                           'face
                           (if (and selectrum--current-candidate-index
                                    (< selectrum--current-candidate-index
                                       0))
                               'selectrum-current-candidate
-                            'minibuffer-prompt))
-                         (propertize "]" 'face 'minibuffer-prompt))))
+                            'minibuffer-prompt)))))
              (minibuf-after-string (or default " "))
              (inserted-res
               (selectrum--insert-candidates


### PR DESCRIPTION
* This variable allows the user to customize the format
  of the default value indicator
* The variable can also be nil in order to hide the indicator
* Do not remove the properties from the candidate string,
  for example Consult uses candidate strings with the invisible
  property
* See also #444

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
