### PR TITLE
Private api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ The format is based on [Keep a Changelog].
   option now ([#305]).
 * The special text property `selectrum-candidate-full` to change the
   canonical representation of a candidate has been removed ([#403]).
+* The `selectrum-read` API has been deprecated and made private. The
+  intention of this change is to encourage users instead to rely on
+  the plain `completing-read` function, which is completion system
+  agnostic ([#446]).
+* The hooks `selectrum-candidate-inserted-hook` and
+  `selectrum-candidate-selected-hook` originally received the
+  arguments passed to `selectrum-read`. Since the `selectrum-read` API
+  has been made private, these additional arguments have been removed
+  from the hook calls. Note that the main user of these hooks is
+  Precient, which ignored the additional arguments up to now ([#446]).
 
 ### Features
 * Line spacing is taken into account when using a fixed window height
@@ -389,6 +399,7 @@ The format is based on [Keep a Changelog].
 [#440]: https://github.com/raxod502/selectrum/pull/440
 [#444]: https://github.com/raxod502/selectrum/pull/444
 [#445]: https://github.com/raxod502/selectrum/pull/445
+[#446]: https://github.com/raxod502/selectrum/pull/446
 
 ## 3.0 (released 2020-10-20)
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -484,22 +484,8 @@ Selectrum-specific functions. Simply use `completing-read` and
 friends, and Selectrum will automatically enhance the experience if
 `selectrum-mode` is enabled.**
 
-However, Selectrum does expose some internal functions as part of its
-public API. The main entry point is the function `selectrum-read`.
-This function is rather like `completing-read`, but with a cleaner
-API. See the docstring for details. The various functions and advice
-installed by Selectrum just call into `selectrum-read` with various
-arguments, after translating whatever Emacs API they implement into
-Selectrum's least common denominator.
-
-Unless you are extending Selectrum to support some very weird function
-which (ab)uses the `completing-read` framework in an interesting way,
-you shouldn't need to use `selectrum-read` directly, as all Emacs
-functions should call into it as appropriate when `selectrum-mode` is
-enabled.
-
-In addition to `selectrum-read`, Selectrum makes available as part of
-its public API some of the functions that wrap `selectrum-read`:
+Selectrum does expose some completion functions as part of its public
+API.
 
 * `selectrum-completing-read` (for `completing-read-function`)
 * `selectrum-completing-read-multiple` (to override
@@ -511,10 +497,10 @@ its public API some of the functions that wrap `selectrum-read`:
 * `selectrum-read-directory-name` (to override `read-directory-name`)
 * `selectrum-read-library-name` (to override `read-library-name`)
 
-You can use these functions in defining variants of Selectrum-based
-commands. If you need to do something more complicated than just
-calling one of these functions with special options, then define your
-own function and call `selectrum-read` directly.
+These functions are used as replacements for the standard completion
+functions when `selectrum-mode` is enabled. If you want to define your
+own commands using completion, it is recommended to use the standard
+`completing-read` API.
 
 ### Sorting, filtering, and highlighting
 
@@ -525,8 +511,7 @@ user option:
 * `selectrum-preprocess-candidates-function` takes the original list
   of candidates and sorts it (actually, it can do any sort of
   preprocessing it wants). Usually preprocessing only happens once.
-  However, if a function is passed to `selectrum-read` to generate the
-  candidate list dynamically based on the user input, then
+  Under special circumstances where the candidate set is dynamic,
   preprocessing happens instead after each input change.
 * `selectrum-refine-candidates-function` takes the preprocessed list
   and filters it using the user's input. This refinement happens every
@@ -820,7 +805,7 @@ seems to provide a similar vertical completion interface to Selectrum.
 
 One problem with Snails is that, like Ivy, it goes the route of
 wrapping every possible command with a "backend" rather than using
-existing Emacs interfaces to handle all possible commands. 
+existing Emacs interfaces to handle all possible commands.
 
 ### Sallet
 

--- a/selectrum-helm.el
+++ b/selectrum-helm.el
@@ -88,9 +88,9 @@ ONLY-ONE non-nil means don't add section headers."
                           sources)))
 
 (defun selectrum-helm--adapter (&rest plist)
-  "Receive arguments to `helm' and invoke `selectrum-read' instead.
+  "Receive arguments to `helm' and invoke `selectrum--read' instead.
 For PLIST, see `helm'. This is an `:override' advice for `helm'."
-  (let* ((result (selectrum-read
+  (let* ((result (selectrum--read
                   (or (plist-get plist :prompt) "pattern: ")
                   (selectrum-helm--normalize-sources
                    (plist-get plist :sources))

--- a/selectrum.el
+++ b/selectrum.el
@@ -2058,15 +2058,6 @@ Only to be used from `selectrum-select-from-history'"
 
 ;;; Main entry points
 
-(defmacro selectrum--let-maybe (pred varlist &rest body)
-  "If PRED evaluates to non-nil, bind variables in VARLIST and eval BODY.
-Otherwise, just eval BODY."
-  (declare (indent 0))
-  `(if ,pred
-       (let ,varlist
-         ,@body)
-     ,@body))
-
 (cl-defun selectrum-read
     (prompt candidates &rest args &key
             default-candidate initial-input require-match


### PR DESCRIPTION
This is only a first step towards #443. Please tell me if we should proceed with this, @clemera. I searched through github and found at least two packages (maybe not yet published), which started to use the `selectrum-read` API.

* https://github.com/stardiviner/kiwix.el
* https://github.com/landakram/org-z/blob/master/org-z-selectrum.el

So I think it is better to do this rather sooner than later, since the situation will get only more problematic the more popular selectrum becomes. Otherwise we just end up with many selectrum-xyz packages, similar to all the ivy-xyz and helm-xyz packages.

The question is which of the packages really need the dynamic candidate function functionality. The packages which really need the dynamic candidate function could instead use the async functionality of consult. However this would then just shift the problem from creating selectrum-xyz packages to creating consult-xyz packages, but at least the resulting packages would be completion system agnostic, which is a step forward. I am considering to cut the consult--read functionality and create some minimal package which could be used instead of the full consult package. But maybe this split is not necessary given that consult is still not super heavy. But this certainly depends on the perspective, consult has 4k lines by now. The minimal package only exposing the enhanced completing read API (consult--read, consult--prompt, consult--multi) would maybe have 1k lines.

I also thought about the dynamic-candidates function of selectrum. The idea I mentioned in #443 to unify dynamic minibuffer completion tables with dynamic candidate functions would work out (given some flag to mark the minibuffer completion table as dynamic). The only problematic piece is really the input rewriting feature.