### PR TITLE
Disable mouse tooltips in Selectrum buffer

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -1779,7 +1779,8 @@ defaults to `completion-extra-properties'."
 CANDIDATES is the list of candidate strings. DEFAULT is the default
 value which can be overridden and BUF the buffer the session was
 started from."
-  (setq-local selectrum-is-active t)
+  ;; Disable mouse tooltips in Selectrum buffer
+  (setq-local show-help-function nil)
   (setq-local selectrum--last-buffer buf)
   (cond (selectrum--repeat
          (delete-minibuffer-contents)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1717,8 +1717,8 @@ defaults to `completion-extra-properties'."
            0 (length displayed-candidate)
            (list
             'mouse-face 'highlight
-            'help-echo
-            "mouse-1: select candidate\nmouse-3: insert candidate"
+            ;; 'help-echo
+            ;; "mouse-1: select candidate\nmouse-3: insert candidate"
             'keymap
             (let ((keymap (make-sparse-keymap)))
               (define-key keymap [mouse-1]
@@ -1779,8 +1779,6 @@ defaults to `completion-extra-properties'."
 CANDIDATES is the list of candidate strings. DEFAULT is the default
 value which can be overridden and BUF the buffer the session was
 started from."
-  ;; Disable mouse tooltips in Selectrum buffer
-  (setq-local show-help-function nil)
   (setq-local selectrum--last-buffer buf)
   (cond (selectrum--repeat
          (delete-minibuffer-contents)


### PR DESCRIPTION
Seems to work for me. See #451. I also removed the redundant selectrum-is-active.