### PR TITLE
Support cycling for in completion in region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ packages. Users of `selectrum-prescient` can update to configure
 `selectrum-prescient-primary-highlight` and
 `selectrum-prescient-secondary-highlight` ([#455]).
 
+### Enhancements
+`selectrum-completion-in-region` does support cycling (as configured
+per `completion-cycle-threshold`) now ([#419], [#456]).
+
+[#419]: https://github.com/raxod502/selectrum/issues/419
 [#455]: https://github.com/raxod502/selectrum/pull/455
+[#456]: https://github.com/raxod502/selectrum/pull/456
 
 ## 3.1 (released 2021-02-21)
 ### Deprecated


### PR DESCRIPTION
See #419 
@minad I did it a bit differently since in Selectrum we filter the collection only initially with a different style and I would like to keep that behavior. You might want to update the consult version for `completion--cycle-threshold` as this also checks for possibly defined threshold by metadata.