### PR TITLE
Fix nil selectrum--previous-input-string in CRM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ per `completion-cycle-threshold`) now ([#419], [#456]).
 [#455]: https://github.com/raxod502/selectrum/pull/455
 [#456]: https://github.com/raxod502/selectrum/pull/456
 
+### Bugs fixed
+When doing `completing-read-multiple`, selecting an additional
+candidate and exiting by pressing `RET` no longer fails when there are
+existing candidates already selected using `TAB` ([#460]).
+
+[#460]: https://github.com/raxod502/selectrum/pull/460
+
 ## 3.1 (released 2021-02-21)
 ### Deprecated
 * The `selectrum-read` API has been deprecated and made private. The

--- a/selectrum.el
+++ b/selectrum.el
@@ -1909,6 +1909,10 @@ plus CANDIDATE."
                                            selectrum--previous-input-string))
                         (let* ((previous-input-string
                                 selectrum--previous-input-string)
+                               (separator
+                                crm-separator)
+                               (full-candidate
+                                (selectrum--get-full candidate))
                                (crm
                                 (if (and selectrum--current-candidate-index
                                          (< selectrum--current-candidate-index
@@ -1918,11 +1922,11 @@ plus CANDIDATE."
                                     (insert previous-input-string)
                                     (goto-char (point-min))
                                     (while (re-search-forward
-                                            crm-separator nil t))
+                                            separator nil t))
                                     (delete-region (point) (point-max))
-                                    (insert (selectrum--get-full candidate))
+                                    (insert full-candidate)
                                     (buffer-string)))))
-                          (dolist (cand (split-string crm crm-separator t))
+                          (dolist (cand (split-string crm separator t))
                             (apply #'run-hook-with-args
                                    'selectrum-candidate-selected-hook
                                    (selectrum--get-full cand)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1907,19 +1907,21 @@ plus CANDIDATE."
   (let* ((result (cond ((and selectrum--is-crm-session
                              (string-match crm-separator
                                            selectrum--previous-input-string))
-                        (let ((crm
-                               (if (and selectrum--current-candidate-index
-                                        (< selectrum--current-candidate-index
-                                           0))
-                                   candidate
-                                 (with-temp-buffer
-                                   (insert selectrum--previous-input-string)
-                                   (goto-char (point-min))
-                                   (while (re-search-forward
-                                           crm-separator nil t))
-                                   (delete-region (point) (point-max))
-                                   (insert (selectrum--get-full candidate))
-                                   (buffer-string)))))
+                        (let* ((previous-input-string
+                                selectrum--previous-input-string)
+                               (crm
+                                (if (and selectrum--current-candidate-index
+                                         (< selectrum--current-candidate-index
+                                            0))
+                                    candidate
+                                  (with-temp-buffer
+                                    (insert previous-input-string)
+                                    (goto-char (point-min))
+                                    (while (re-search-forward
+                                            crm-separator nil t))
+                                    (delete-region (point) (point-max))
+                                    (insert (selectrum--get-full candidate))
+                                    (buffer-string)))))
                           (dolist (cand (split-string crm crm-separator t))
                             (apply #'run-hook-with-args
                                    'selectrum-candidate-selected-hook


### PR DESCRIPTION
When hitting the return key on a candidate while existing candidates have been selected already, I get `(wrong-type-argument char-or-string-p nil)`.

I figured out it's because `selectrum--previous-input-string` is a buffer-local variable, which I think makes it `nil` later on inside `with-temp-buffer` which is used to clean up the candidate list and append on the selected one.

I'm pretty new to emacs and elisp in general, so while this fix works for me, maybe you can suggest a better one?