### PR TITLE
Group function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
 ## Unreleased
+### Features
+* Add support for `x-group-function` completion metadata. The group
+  title formatting is controlled by the customization variable
+  `selectrum-group-format` and the faces `selectrum-group-separator`
+  and `selectrum-group-title` ([#458], [#463]).
+
 ### Deprecated
 The faces `selectrum-primary-highlight` and
 `selectrum-secondary-highlight` have been deprecated. The match
@@ -29,9 +35,11 @@ packages. Users of `selectrum-prescient` can update to configure
 [#419]: https://github.com/raxod502/selectrum/issues/419
 [#455]: https://github.com/raxod502/selectrum/pull/455
 [#456]: https://github.com/raxod502/selectrum/pull/456
+[#458]: https://github.com/raxod502/selectrum/pull/458
 [#459]: https://github.com/raxod502/selectrum/issues/459
 [#460]: https://github.com/raxod502/selectrum/pull/460
 [#462]: https://github.com/raxod502/selectrum/pull/462
+[#463]: https://github.com/raxod502/selectrum/pull/463
 
 ## 3.1 (released 2021-02-21)
 ### Deprecated

--- a/selectrum.el
+++ b/selectrum.el
@@ -136,7 +136,8 @@ parts of the input."
   :prefix "selectrum-"
   :link '(url-link "https://github.com/raxod502/selectrum"))
 
-(defcustom selectrum-default-value-format " [default: %s]"
+(defcustom selectrum-default-value-format
+  (propertize " [default: %s]" 'face 'minibuffer-prompt)
   "Format string for the default value in the minibuffer."
   :type '(choice (const nil) string))
 
@@ -1323,8 +1324,7 @@ the update."
                                 (not minibuffer-completing-file-name)
                                 (not (member selectrum--default-candidate
                                              selectrum--refined-candidates)))))
-                 (format (propertize selectrum-default-value-format
-                                     'face 'minibuffer-prompt)
+                 (format selectrum-default-value-format
                          (propertize
                           (or selectrum--default-candidate "\"\"")
                           'face
@@ -1332,7 +1332,9 @@ the update."
                                    (< selectrum--current-candidate-index
                                       0))
                               'selectrum-current-candidate
-                            'minibuffer-prompt)))))
+                            (get-text-property
+                             0 'face
+                             selectrum-default-value-format))))))
              (minibuf-after-string (or default " "))
              (inserted-res
               (selectrum--insert-candidates

--- a/selectrum.el
+++ b/selectrum.el
@@ -1690,90 +1690,90 @@ defaults to `completion-extra-properties'."
          (show-indices selectrum-show-indices)
          (margin-padding selectrum-right-margin-padding)
          (lines))
-    (dolist (candidate candidates)
-      (when (string-match-p "\n" candidate)
-        (setq candidate (selectrum--ensure-single-line
-                         candidate
-                         selectrum-multiline-display-settings)))
-      (let* ((prefix (get-text-property
-                      0 'selectrum-candidate-display-prefix
-                      candidate))
-             (suffix (get-text-property
-                      0 'selectrum-candidate-display-suffix
-                      candidate))
-             (right-margin (get-text-property
-                            0 'selectrum-candidate-display-right-margin
-                            candidate))
-             (displayed-candidate
-              (selectrum--display-string
-               (if annot-fun
-                   candidate
-                 (concat prefix candidate suffix))))
-             (formatting-current-candidate
-              (equal index highlighted-index)))
-        ;; Add the ability to interact with candidates via the mouse.
-        (add-text-properties
-         0 (length displayed-candidate)
-         (list
-          'mouse-face 'highlight
-          ;; 'help-echo
-          ;; "mouse-1: select candidate\nmouse-3: insert candidate"
-          'keymap
-          (let ((keymap (make-sparse-keymap)))
-            (define-key keymap [mouse-1]
-              `(lambda ()
-                 (interactive)
-                 (selectrum-select-current-candidate ,(1+ index))))
-            (define-key keymap [mouse-3]
-              `(lambda ()
-                 (interactive)
-                 (selectrum-insert-current-candidate ,(1+ index))))
-            keymap))
-         displayed-candidate)
-        (when formatting-current-candidate
-          (setq displayed-candidate
-                (selectrum--selection-highlight displayed-candidate))
-          (when annot-fun
-            (funcall annot-fun prefix suffix right-margin)))
-        (when show-indices
-          (let* ((display-fn (if (functionp show-indices)
-                                 show-indices
-                               (lambda (i) (format "%2d " i))))
-                 (curr-index (substring-no-properties
-                              (funcall display-fn (1+ index)))))
+      (dolist (candidate candidates)
+        (when (string-match-p "\n" candidate)
+          (setq candidate (selectrum--ensure-single-line
+                           candidate
+                           selectrum-multiline-display-settings)))
+        (let* ((prefix (get-text-property
+                        0 'selectrum-candidate-display-prefix
+                        candidate))
+               (suffix (get-text-property
+                        0 'selectrum-candidate-display-suffix
+                        candidate))
+               (right-margin (get-text-property
+                              0 'selectrum-candidate-display-right-margin
+                              candidate))
+               (displayed-candidate
+                (selectrum--display-string
+                 (if annot-fun
+                     candidate
+                   (concat prefix candidate suffix))))
+               (formatting-current-candidate
+                (equal index highlighted-index)))
+          ;; Add the ability to interact with candidates via the mouse.
+          (add-text-properties
+           0 (length displayed-candidate)
+           (list
+            'mouse-face 'highlight
+            ;; 'help-echo
+            ;; "mouse-1: select candidate\nmouse-3: insert candidate"
+            'keymap
+            (let ((keymap (make-sparse-keymap)))
+              (define-key keymap [mouse-1]
+                `(lambda ()
+                   (interactive)
+                   (selectrum-select-current-candidate ,(1+ index))))
+              (define-key keymap [mouse-3]
+                `(lambda ()
+                   (interactive)
+                   (selectrum-insert-current-candidate ,(1+ index))))
+              keymap))
+           displayed-candidate)
+          (when formatting-current-candidate
             (setq displayed-candidate
-                  (concat (propertize curr-index 'face 'minibuffer-prompt)
-                          displayed-candidate))))
-        (cond
-         ((and right-margin (not annot-fun))
-          (setq displayed-candidate
-                (concat
-                 displayed-candidate
-                 (propertize
-                  " "
-                  'face
-                  (when formatting-current-candidate
-                    'selectrum-current-candidate)
-                  'display
-                  `(space :align-to (- right-fringe
-                                       ,(string-width right-margin)
-                                       ,margin-padding)))
-                 (if formatting-current-candidate
-                     (selectrum--selection-highlight right-margin)
-                   right-margin))))
-         ((and extend
-               formatting-current-candidate)
-          (setq displayed-candidate
-                (concat
-                 displayed-candidate
-                 (propertize
-                  " "
-                  'face 'selectrum-current-candidate
-                  'display
-                  `(space :align-to (- right-fringe
-                                       ,margin-padding)))))))
-        (push displayed-candidate lines)
-        (cl-incf index)))
+                  (selectrum--selection-highlight displayed-candidate))
+            (when annot-fun
+              (funcall annot-fun prefix suffix right-margin)))
+          (when show-indices
+            (let* ((display-fn (if (functionp show-indices)
+                                   show-indices
+                                 (lambda (i) (format "%2d " i))))
+                   (curr-index (substring-no-properties
+                                (funcall display-fn (1+ index)))))
+              (setq displayed-candidate
+                    (concat (propertize curr-index 'face 'minibuffer-prompt)
+                            displayed-candidate))))
+          (cond
+           ((and right-margin (not annot-fun))
+            (setq displayed-candidate
+                  (concat
+                   displayed-candidate
+                   (propertize
+                    " "
+                    'face
+                    (when formatting-current-candidate
+                      'selectrum-current-candidate)
+                    'display
+                    `(space :align-to (- right-fringe
+                                         ,(string-width right-margin)
+                                         ,margin-padding)))
+                   (if formatting-current-candidate
+                       (selectrum--selection-highlight right-margin)
+                     right-margin))))
+           ((and extend
+                 formatting-current-candidate)
+            (setq displayed-candidate
+                  (concat
+                   displayed-candidate
+                   (propertize
+                    " "
+                    'face 'selectrum-current-candidate
+                    'display
+                    `(space :align-to (- right-fringe
+                                         ,margin-padding)))))))
+          (push displayed-candidate lines)
+          (cl-incf index)))
     (nreverse lines)))
 
 (defun selectrum--minibuffer-setup-hook (candidates default buf)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1718,7 +1718,10 @@ defaults to `completion-extra-properties'."
          (groups (if (or horizontalp (not groupf))
                      (list (cons nil candidates))
                    (funcall groupf candidates)))
-         (show-indices selectrum-show-indices)
+         (show-indices
+          (cond
+           ((functionp selectrum-show-indices) selectrum-show-indices)
+           (selectrum-show-indices (lambda (i) (format "%2d " i)))))
          (margin-padding selectrum-right-margin-padding)
          (lines))
     (dolist (group groups)
@@ -1770,14 +1773,10 @@ defaults to `completion-extra-properties'."
             (when annot-fun
               (funcall annot-fun prefix suffix right-margin)))
           (when show-indices
-            (let* ((display-fn (if (functionp show-indices)
-                                   show-indices
-                                 (lambda (i) (format "%2d " i))))
-                   (curr-index (substring-no-properties
-                                (funcall display-fn (1+ index)))))
-              (setq displayed-candidate
-                    (concat (propertize curr-index 'face 'minibuffer-prompt)
-                            displayed-candidate))))
+            (setq displayed-candidate
+                  (concat (propertize (funcall show-indices (1+ index))
+                                      'face 'minibuffer-prompt)
+                          displayed-candidate)))
           (cond
            ((and right-margin (not annot-fun))
             (setq displayed-candidate

--- a/selectrum.el
+++ b/selectrum.el
@@ -1479,13 +1479,11 @@ SETTINGS, see `selectrum-multiline-display-settings'."
          (lines (split-string cand "\n"))
          (len (length lines))
          (input (minibuffer-contents))
-         (first-line (with-temp-buffer
-                       (insert cand)
-                       (goto-char (point-min))
-                       (skip-chars-forward " \t\n")
-                       (buffer-substring
-                        (line-beginning-position)
-                        (line-end-position))))
+         (first-line
+          (save-match-data
+            (if (string-match "\\`\\(?:[ \t]*\n\\)*\\([^\n]*\\)" cand)
+                (match-string 1 cand)
+              cand)))
          (matches (delete
                    first-line
                    (if (string-empty-p input)

--- a/selectrum.el
+++ b/selectrum.el
@@ -1669,8 +1669,7 @@ suffix."
 (defun selectrum--candidates-display-strings (candidates
                                               highlighted-index
                                               annot-fun
-                                              horizontalp
-                                              &optional table pred props)
+                                              horizontalp)
   "Get display strings for CANDIDATES.
 HIGHLIGHTED-INDEX is the currently selected index. If ANNOT-FUN
 is non-nil don't add any annotations but call the function with
@@ -1680,12 +1679,11 @@ horizontally. TABLE defaults to `minibuffer-completion-table'.
 PRED defaults to `minibuffer-completion-predicate'. PROPS
 defaults to `completion-extra-properties'."
   (let* ((index 0)
-         (props (or props completion-extra-properties))
-         (annotf (or (selectrum--get-meta 'annotation-function table pred)
-                     (plist-get props :annotation-function)))
-         (aff (or (selectrum--get-meta 'affixation-function table pred)
-                  (plist-get props :affixation-function)))
-         (docsigf (plist-get props :company-docsig))
+         (annotf (or (selectrum--get-meta 'annotation-function)
+                     (plist-get completion-extra-properties :annotation-function)))
+         (aff (or (selectrum--get-meta 'affixation-function)
+                  (plist-get completion-extra-properties :affixation-function)))
+         (docsigf (plist-get completion-extra-properties :company-docsig))
          (candidates (cond (aff
                             (selectrum--affixate aff candidates))
                            ((or annotf docsigf)

--- a/selectrum.el
+++ b/selectrum.el
@@ -256,9 +256,7 @@ Uses `completion-styles'."
   (nconc
    (completion-all-completions
     input candidates nil (length input)
-    (completion-metadata input
-                         minibuffer-completion-table
-                         minibuffer-completion-predicate))
+    (selectrum--metadata input))
    nil))
 
 (defcustom selectrum-refine-candidates-function
@@ -812,17 +810,16 @@ behavior."
      (minibuffer-prompt-end)
      (point-max))))
 
-(defun selectrum--get-meta (setting &optional table pred input)
-  "Get metadata SETTING from TABLE.
-TABLE defaults to `minibuffer-completion-table'.
-PRED defaults to `minibuffer-completion-predicate'.
-INPUT defaults to current selectrum input string."
-  (let ((input (or input (minibuffer-contents)))
-        (pred (or pred minibuffer-completion-predicate))
-        (table (or table minibuffer-completion-table)))
-    (when table
-      (completion-metadata-get
-       (completion-metadata input table pred) setting))))
+(defun selectrum--metadata (&optional input)
+  "Get completion metadata.
+INPUT defaults to current input string."
+  (completion-metadata (or input (minibuffer-contents))
+                       minibuffer-completion-table
+                       minibuffer-completion-predicate))
+
+(defun selectrum--get-meta (setting)
+  "Get metadata SETTING from completion table."
+  (completion-metadata-get (selectrum--metadata) setting))
 
 (defun selectrum-exhibit (&optional keep-selection)
   "Trigger an update of Selectrum's completion UI.
@@ -1696,11 +1693,12 @@ horizontally. TABLE defaults to `minibuffer-completion-table'.
 PRED defaults to `minibuffer-completion-predicate'. PROPS
 defaults to `completion-extra-properties'."
   (let* ((index 0)
-         (annotf (or (selectrum--get-meta 'annotation-function)
+         (metadata (selectrum--metadata))
+         (annotf (or (completion-metadata-get metadata 'annotation-function)
                      (plist-get completion-extra-properties :annotation-function)))
-         (aff (or (selectrum--get-meta 'affixation-function)
+         (aff (or (completion-metadata-get metadata 'affixation-function)
                   (plist-get completion-extra-properties :affixation-function)))
-         (groupf (or (selectrum--get-meta 'x-group-function)
+         (groupf (or (completion-metadata-get metadata 'x-group-function)
                      (plist-get completion-extra-properties :x-group-function)))
          (docsigf (plist-get completion-extra-properties :company-docsig))
          (candidates (cond (aff

--- a/selectrum.el
+++ b/selectrum.el
@@ -1688,90 +1688,93 @@ defaults to `completion-extra-properties'."
                           (or aff annotf docsigf)
                         selectrum-extend-current-candidate-highlight)))
          (show-indices selectrum-show-indices)
-         (margin-padding selectrum-right-margin-padding))
-    (with-temp-buffer
-      (dolist (candidate candidates)
-        (when (string-match-p "\n" candidate)
-          (setq candidate (selectrum--ensure-single-line
-                           candidate
-                           selectrum-multiline-display-settings)))
-        (let* ((prefix (get-text-property
-                        0 'selectrum-candidate-display-prefix
-                        candidate))
-               (suffix (get-text-property
-                        0 'selectrum-candidate-display-suffix
-                        candidate))
-               (right-margin (get-text-property
-                              0 'selectrum-candidate-display-right-margin
-                              candidate))
-               (displayed-candidate
-                (selectrum--display-string
-                 (if annot-fun
-                     candidate
-                   (concat prefix candidate suffix))))
-               (formatting-current-candidate
-                (equal index highlighted-index)))
-          ;; Add the ability to interact with candidates via the mouse.
-          (add-text-properties
-           0 (length displayed-candidate)
-           (list
-            'mouse-face 'highlight
-            ;; 'help-echo
-            ;; "mouse-1: select candidate\nmouse-3: insert candidate"
-            'keymap
-            (let ((keymap (make-sparse-keymap)))
-              (define-key keymap [mouse-1]
-                `(lambda ()
-                   (interactive)
-                   (selectrum-select-current-candidate ,(1+ index))))
-              (define-key keymap [mouse-3]
-                `(lambda ()
-                   (interactive)
-                   (selectrum-insert-current-candidate ,(1+ index))))
-              keymap))
-           displayed-candidate)
-          (when formatting-current-candidate
+         (margin-padding selectrum-right-margin-padding)
+         (lines))
+    (dolist (candidate candidates)
+      (when (string-match-p "\n" candidate)
+        (setq candidate (selectrum--ensure-single-line
+                         candidate
+                         selectrum-multiline-display-settings)))
+      (let* ((prefix (get-text-property
+                      0 'selectrum-candidate-display-prefix
+                      candidate))
+             (suffix (get-text-property
+                      0 'selectrum-candidate-display-suffix
+                      candidate))
+             (right-margin (get-text-property
+                            0 'selectrum-candidate-display-right-margin
+                            candidate))
+             (displayed-candidate
+              (selectrum--display-string
+               (if annot-fun
+                   candidate
+                 (concat prefix candidate suffix))))
+             (formatting-current-candidate
+              (equal index highlighted-index)))
+        ;; Add the ability to interact with candidates via the mouse.
+        (add-text-properties
+         0 (length displayed-candidate)
+         (list
+          'mouse-face 'highlight
+          ;; 'help-echo
+          ;; "mouse-1: select candidate\nmouse-3: insert candidate"
+          'keymap
+          (let ((keymap (make-sparse-keymap)))
+            (define-key keymap [mouse-1]
+              `(lambda ()
+                 (interactive)
+                 (selectrum-select-current-candidate ,(1+ index))))
+            (define-key keymap [mouse-3]
+              `(lambda ()
+                 (interactive)
+                 (selectrum-insert-current-candidate ,(1+ index))))
+            keymap))
+         displayed-candidate)
+        (when formatting-current-candidate
+          (setq displayed-candidate
+                (selectrum--selection-highlight displayed-candidate))
+          (when annot-fun
+            (funcall annot-fun prefix suffix right-margin)))
+        (when show-indices
+          (let* ((display-fn (if (functionp show-indices)
+                                 show-indices
+                               (lambda (i) (format "%2d " i))))
+                 (curr-index (substring-no-properties
+                              (funcall display-fn (1+ index)))))
             (setq displayed-candidate
-                  (selectrum--selection-highlight displayed-candidate))
-            (when annot-fun
-              (funcall annot-fun prefix suffix right-margin)))
-          (insert "\n")
-          (when show-indices
-            (let* ((display-fn (if (functionp show-indices)
-                                   show-indices
-                                 (lambda (i) (format "%2d " i))))
-                   (curr-index (substring-no-properties
-                                (funcall display-fn (1+ index)))))
-              (insert
-               (propertize curr-index 'face 'minibuffer-prompt))))
-          (insert displayed-candidate)
-          (cond
-           ((and right-margin (not annot-fun))
-            (insert
-             (concat
-              (propertize
-               " "
-               'face
-               (when formatting-current-candidate
-                 'selectrum-current-candidate)
-               'display
-               `(space :align-to (- right-fringe
-                                    ,(string-width right-margin)
-                                    ,margin-padding)))
-              (if formatting-current-candidate
-                  (selectrum--selection-highlight right-margin)
-                right-margin))))
-           ((and extend
-                 formatting-current-candidate)
-            (insert
-             (propertize
-              " "
-              'face 'selectrum-current-candidate
-              'display
-              `(space :align-to (- right-fringe
-                                   ,margin-padding)))))))
-        (cl-incf index))
-      (split-string (buffer-string) "\n" t))))
+                  (concat (propertize curr-index 'face 'minibuffer-prompt)
+                          displayed-candidate))))
+        (cond
+         ((and right-margin (not annot-fun))
+          (setq displayed-candidate
+                (concat
+                 displayed-candidate
+                 (propertize
+                  " "
+                  'face
+                  (when formatting-current-candidate
+                    'selectrum-current-candidate)
+                  'display
+                  `(space :align-to (- right-fringe
+                                       ,(string-width right-margin)
+                                       ,margin-padding)))
+                 (if formatting-current-candidate
+                     (selectrum--selection-highlight right-margin)
+                   right-margin))))
+         ((and extend
+               formatting-current-candidate)
+          (setq displayed-candidate
+                (concat
+                 displayed-candidate
+                 (propertize
+                  " "
+                  'face 'selectrum-current-candidate
+                  'display
+                  `(space :align-to (- right-fringe
+                                       ,margin-padding)))))))
+        (push displayed-candidate lines)
+        (cl-incf index)))
+    (nreverse lines)))
 
 (defun selectrum--minibuffer-setup-hook (candidates default buf)
   "Set up minibuffer for interactive candidate selection.


### PR DESCRIPTION
Corresponding PR for #458. I implemented the `group-function`. You may want to pull the first four simplification commits directly. In order to test the grouping feature, you can `eval-buffer` consult.el from https://github.com/minad/consult/pull/234.

consult-mode-command:
![cmd](https://user-images.githubusercontent.com/50754/109176443-1f0a6f80-7787-11eb-92f8-326d615f04af.png)
