### PR TITLE
Drop Emacs 25 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,18 +9,6 @@ shared: &shared
         make docker
         CMD="make -k lint"
 jobs:
-  emacs-25.1:
-    <<: *shared
-    environment:
-      VERSION: "25.1"
-  emacs-25.2:
-    <<: *shared
-    environment:
-      VERSION: "25.2"
-  emacs-25.3:
-    <<: *shared
-    environment:
-      VERSION: "25.3"
   emacs-26.1:
     <<: *shared
     environment:
@@ -37,9 +25,6 @@ workflows:
   version: 2
   ci:
     jobs:
-      - emacs-25.1
-      - emacs-25.2
-      - emacs-25.3
       - emacs-26.1
       - emacs-26.2
       - emacs-git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ jobs:
     <<: *shared
     environment:
       VERSION: "26.2"
+  emacs-27.1:
+    <<: *shared
+    environment:
+      VERSION: "27.1"
   emacs-git:
     <<: *shared
     environment:
@@ -27,4 +31,5 @@ workflows:
     jobs:
       - emacs-26.1
       - emacs-26.2
+      - emacs-27.1
       - emacs-git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
 ## Unreleased
+### Breaking changes
+* Support for Emacs versions older than 26.1 has been removed
+  ([#465]).
+
 ### Features
 * Add support for `x-group-function` completion metadata. The group
   title formatting is controlled by the customization variable
@@ -40,6 +44,7 @@ packages. Users of `selectrum-prescient` can update to configure
 [#460]: https://github.com/raxod502/selectrum/pull/460
 [#462]: https://github.com/raxod502/selectrum/pull/462
 [#463]: https://github.com/raxod502/selectrum/pull/463
+[#465]: https://github.com/raxod502/selectrum/pull/465
 
 ## 3.1 (released 2021-02-21)
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### Breaking changes
-* Support for Emacs versions older than 26.1 has been removed
-  ([#465]).
+* Support for Emacs versions older than 26.1 has been removed ([#454],
+  [#465]).
 
 ### Features
 * Add support for `x-group-function` completion metadata. The group
@@ -37,6 +37,7 @@ packages. Users of `selectrum-prescient` can update to configure
   are existing candidates already selected using `TAB` ([#460]).
 
 [#419]: https://github.com/raxod502/selectrum/issues/419
+[#454]: https://github.com/raxod502/selectrum/issues/454
 [#455]: https://github.com/raxod502/selectrum/pull/455
 [#456]: https://github.com/raxod502/selectrum/pull/456
 [#458]: https://github.com/raxod502/selectrum/pull/458

--- a/README.md
+++ b/README.md
@@ -584,12 +584,6 @@ Technical points:
 * There is no built-in support for alternate actions on minibuffer
   candidates but you can add those using
   [embark](https://github.com/oantolin/embark/).
-* In Emacs 25 and earlier, `M-x ffap` is basically completely broken.
-  This is because in old versions of Emacs, `ffap` worked by calling
-  `completing-read` directly with a special completion table function,
-  rather than just using `read-file-name` like would be reasonable.
-  Since Emacs 25 is going to die eventually, I'm not going to bother
-  fixing this, although pull requests would be accepted.
 * In Emacs 26 and earlier, the way that messages are displayed while
   the minibuffer is active is unworkably bad: they block out the
   entire minibuffer as long as they are displayed, and then mess up

--- a/selectrum-helm.el
+++ b/selectrum-helm.el
@@ -6,7 +6,7 @@
 ;; Created: 15 Apr 2020
 ;; Homepage: https://github.com/raxod502/selectrum
 ;; Keywords: extensions
-;; Package-Requires: ((emacs "25.1") (helm "3.6.1") (selectrum "3.1"))
+;; Package-Requires: ((emacs "26.1") (helm "3.6.1") (selectrum "3.1"))
 ;; SPDX-License-Identifier: MIT
 ;; Version: 3.1
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -6,7 +6,7 @@
 ;; Created: 8 Dec 2019
 ;; Homepage: https://github.com/raxod502/selectrum
 ;; Keywords: extensions
-;; Package-Requires: ((emacs "25.1"))
+;; Package-Requires: ((emacs "26.1"))
 ;; SPDX-License-Identifier: MIT
 ;; Version: 3.1
 
@@ -1157,7 +1157,7 @@ and the `x-group-function'."
                                    :x-group-function)))
     (setq-local
      selectrum--preprocessed-candidates
-     (cl-mapcan #'cdr (funcall groupf selectrum--preprocessed-candidates))))
+     (mapcan #'cdr (funcall groupf selectrum--preprocessed-candidates))))
   (setq-local
    selectrum--total-num-candidates
    (length selectrum--preprocessed-candidates)))

--- a/selectrum.el
+++ b/selectrum.el
@@ -1157,7 +1157,7 @@ and the `x-group-function'."
                                    :x-group-function)))
     (setq-local
      selectrum--preprocessed-candidates
-     (mapcan #'cdr (funcall groupf selectrum--preprocessed-candidates))))
+     (cl-mapcan #'cdr (funcall groupf selectrum--preprocessed-candidates))))
   (setq-local
    selectrum--total-num-candidates
    (length selectrum--preprocessed-candidates)))


### PR DESCRIPTION
Emacs 26 is usually the minimal version in use and this will free us from adapting the development for the older versions see #454.