### PR TITLE
Perform grouping after refinement, allow reordering during refinement

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -254,8 +254,7 @@ Use `selectrum-cycle-display-style' to cycle through these."
 Uses `completion-styles'."
   (nconc
    (completion-all-completions
-    input candidates nil (length input)
-    (selectrum--metadata input))
+    input candidates nil (length input))
    nil))
 
 (defcustom selectrum-refine-candidates-function
@@ -775,10 +774,9 @@ behavior."
      (minibuffer-prompt-end)
      (point-max))))
 
-(defun selectrum--metadata (&optional input)
-  "Get completion metadata.
-INPUT defaults to current input string."
-  (completion-metadata (or input (minibuffer-contents))
+(defun selectrum--metadata ()
+  "Get completion metadata."
+  (completion-metadata (minibuffer-contents)
                        minibuffer-completion-table
                        minibuffer-completion-predicate))
 

--- a/selectrum.el
+++ b/selectrum.el
@@ -1062,24 +1062,7 @@ and the `x-group-function'."
   ;; TODO: Why is it necessary to remove empty candidates?
   ;; Where do empty candidates actually come from?
   (setq-local selectrum--preprocessed-candidates
-              (delete "" selectrum--preprocessed-candidates))
-  (when-let (groupf (or (selectrum--get-meta 'x-group-function)
-                        (plist-get completion-extra-properties
-                                   :x-group-function)))
-    ;; Ensure that default candidate appears at the top if
-    ;; `selectrum-move-default-candidate' is set. It is redundant to
-    ;; do this here, since we move the candidate also during
-    ;; refinement. However this way the grouping function is informed
-    ;; of the desired candidate order.
-    (when (and selectrum-move-default-candidate
-               selectrum--default-candidate)
-      (setq-local selectrum--preprocessed-candidates
-                  (selectrum--move-to-front-destructive
-                   selectrum--default-candidate
-                   selectrum--preprocessed-candidates)))
-    (setq-local
-     selectrum--preprocessed-candidates
-     (mapcan #'cdr (funcall groupf selectrum--preprocessed-candidates)))))
+              (delete "" selectrum--preprocessed-candidates)))
 
 (defun selectrum--update-dynamic-candidates (input)
   "Update dynamic candidate set with new INPUT."
@@ -1132,6 +1115,25 @@ and the `x-group-function'."
     (setq-local selectrum--refined-candidates
                 (funcall selectrum-refine-candidates-function
                          input cands)))
+  ;; Group candidates. This has to be done after refinement, since
+  ;; refinement can reorder the candidates.
+  (when-let (groupf (or (selectrum--get-meta 'x-group-function)
+                        (plist-get completion-extra-properties
+                                   :x-group-function)))
+    ;; Ensure that default candidate appears at the top if
+    ;; `selectrum-move-default-candidate' is set. It is redundant to
+    ;; do this here, since we move the default candidate also
+    ;; afterwards. However this way the grouping function is informed
+    ;; of the desired candidate order.
+    (when (and selectrum-move-default-candidate
+               selectrum--default-candidate)
+      (setq-local selectrum--refined-candidates
+                  (selectrum--move-to-front-destructive
+                   selectrum--default-candidate
+                   selectrum--refined-candidates)))
+    (setq-local
+     selectrum--refined-candidates
+     (mapcan #'cdr (funcall groupf selectrum--refined-candidates))))
   (when selectrum--virtual-default-file
     (unless (equal selectrum--virtual-default-file "")
       (setq-local selectrum--refined-candidates


### PR DESCRIPTION
After #476, I was wondering when the grouping should actually be performed.

I made a small experiment: One thing I always found annoying about the Orderless style matching, is that prefix matching strings are not preferred. Usually I start to type some prefix and then refine with the following tokens. The code here is just an experiment not ready to be merged, since it contains Consult/Orderless-specific hacks.

It may still be interesting to discuss this:

* Should such a reordering rather be done on the level of the completion style to allow more general usage? Or is it a hard rule that completion styles only filter and do not perform any kind of reordering?

* In Selectrum we may want to reconsider where we actually do the grouping. Currently we do the grouping after the initial sorting, which works best when the candidate ordering stays the same when the candidates are filtered afterwards. In Icomplete-vertical we perform the grouping after filtering/sorting, more specifically after `completion-all-sorted-completions`. This would mean we should also do the grouping after refinement here to stay consistent. Then we can encourage reordering candidates during refinement and actually allow use cases like moving prefix matching strings to the front.

cc @oantolin 