### PR TITLE
Rework display

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -934,6 +934,8 @@ the `horizontal' description of `selectrum-display-style'."
       (let ((ncols ncols))
         (while (and cands (> ncols 0))
           (let ((cand (pop cands)))
+            (setq cand (string-trim (replace-regexp-in-string
+                                     "[ \t][ \t]+" " " cand)))
             (when (zerop n)
               (setq ncols (- ncols (length start)))
               (push start insert))

--- a/selectrum.el
+++ b/selectrum.el
@@ -867,16 +867,23 @@ displayed first and LAST-INDEX-DISPLAYED the index of the last one."
              (max (- (1+ max-index) nrows)
                   0))))
          (displayed-candidates
-          (mapcar #'car
-                  (selectrum--format-candidates
-                   input index
-                   first-index-displayed nrows 'should-annotate))))
+          (selectrum--format-candidates
+           input index
+           first-index-displayed nrows 'should-annotate))
+         (last-title)
+         (lines))
+    (dolist (cand displayed-candidates)
+      (when-let (title (and selectrum-group-format (cdr cand)))
+        (unless (equal title last-title)
+          (setq last-title title)
+          (push (format selectrum-group-format title) lines)))
+      (push (car cand) lines))
     (list
      (length displayed-candidates)
      first-index-displayed
      (if displayed-candidates
          (concat (and (window-minibuffer-p win) "\n")
-                 (string-join displayed-candidates "\n"))
+                 (string-join (nreverse lines) "\n"))
        ""))))
 
 (defun selectrum--horizontal-display-style

--- a/selectrum.el
+++ b/selectrum.el
@@ -1687,7 +1687,7 @@ If SHOULD-ANNOTATE is non-nil candidate annotations are added."
                      0 'selectrum-candidate-display-suffix
                      candidate))
                  single-line-candidate)))
-            (formatting-current-candidate
+             (formatting-current-candidate
               (equal index highlighted-index)))
         ;; Add the ability to interact with candidates via the mouse.
         (add-text-properties

--- a/selectrum.el
+++ b/selectrum.el
@@ -867,7 +867,7 @@ displayed first and LAST-INDEX-DISPLAYED the index of the last one."
              (max (- (1+ max-index) nrows)
                   0))))
          (displayed-candidates
-          (selectrum--candidates-display-strings
+          (selectrum--format-candidates
            input index
            first-index-displayed nrows nil)))
     (list
@@ -914,7 +914,7 @@ the `horizontal' description of `selectrum-display-style'."
                 (t
                  first-index-displayed)))
          (cands
-          (selectrum--candidates-display-strings
+          (selectrum--format-candidates
            input index
            first-index-displayed
            (floor ncols (1+ (length separator)))
@@ -1608,7 +1608,7 @@ suffix."
                                    suffix))))))
             res))))
 
-(defun selectrum--candidates-display-strings
+(defun selectrum--format-candidates
     (input current-index first-index-displayed ncands horizontalp)
   "Get display strings for CANDIDATES.
 INPUT is the input string for highlighting.

--- a/selectrum.el
+++ b/selectrum.el
@@ -1643,14 +1643,17 @@ If SHOULD-ANNOTATE is non-nil candidate annotations are added."
          (index 0)
          (metadata (selectrum--metadata))
          (annotf (and should-annotate
-                      (or (completion-metadata-get metadata 'annotation-function)
+                      (or (completion-metadata-get metadata
+                                                   'annotation-function)
                           (plist-get completion-extra-properties
                                      :annotation-function))))
          (aff (and should-annotate
-                   (or (completion-metadata-get metadata 'affixation-function)
+                   (or (completion-metadata-get metadata
+                                                'affixation-function)
                        (plist-get completion-extra-properties
                                   :affixation-function))))
-         (groupf (or (completion-metadata-get metadata 'x-group-function)
+         (groupf (or (completion-metadata-get metadata
+                                              'x-group-function)
                      (plist-get completion-extra-properties
                                 :x-group-function)))
          (docsigf (plist-get completion-extra-properties :company-docsig))
@@ -1738,15 +1741,16 @@ If SHOULD-ANNOTATE is non-nil candidate annotations are added."
                            'auto)
                        (or aff annotf docsigf)
                      selectrum-extend-current-candidate-highlight))
-              (setq displayed-candidate
-                    (concat
-                     displayed-candidate
-                     (propertize
-                      " "
-                      'face 'selectrum-current-candidate
-                      'display
-                      `(space :align-to (- right-fringe
-                                           ,selectrum-right-margin-padding)))))))))
+              (setq
+               displayed-candidate
+               (concat
+                displayed-candidate
+                (propertize
+                 " "
+                 'face 'selectrum-current-candidate
+                 'display
+                 `(space :align-to (- right-fringe
+                                      ,selectrum-right-margin-padding)))))))))
         (push (cons
                displayed-candidate
                (and groupf (caar (funcall groupf (list candidate)))))


### PR DESCRIPTION
@clemera I reworked this now. I went with a simple solution - it is all not that bad. We format the candidate strings and return `(candidate . group)` pairs. We can generalize this more when we actually need it, for example when we want `(candidate group prefix suffix)`. Instead of `horizp` we have `should-annotate` now and we only call the annotation functions when really needed.