### PR TITLE
Elaborate on Icicles section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,8 +748,20 @@ Selectrum eventually.
 
 ### Icicles
 
-[Icicles is maintained on EmacsWiki, enough
-said.](https://github.com/melpa/melpa/pull/5008)
+[Icicles](https://www.emacswiki.org/emacs/Icicles) is a package
+somewhat like Helm, written by [Drew
+Adams](https://www.emacswiki.org/emacs/DrewAdams). Like other packages
+by Drew, Icicles is only available for manual download from EmacsWiki.
+[It has been removed from
+MELPA](https://github.com/melpa/melpa/pull/5008) due to community
+consensus that this distribution mechanism has unacceptable security
+risks, but Drew has declined to migrate to any other distribution
+mechanism.
+
+Because of this situation, I have never attempted to use Icicles, and
+cannot comment on the package on the basis of its features. If you
+would like to submit a pull request explaining the advantages and/or
+disadvantages of Icicles versus Selectrum, we would appreciate it.
 
 ### Snails
 


### PR DESCRIPTION
I received a personal email the other week pointing out that [the Icicles section in the README](https://github.com/raxod502/selectrum/tree/21cee863a07f9114172d5b9bd33eeed7f11bcf66#icicles) does not address the features of Icicles in comparison to those of Selectrum, and that the tone reads as disrespectful.

This pull request updates that section of the README to make it clear that distribution by EmacsWiki is a serious problem, but that this does not have bearing on the functionality of Icicles.

If anyone else has revisions they would like to make such that this section, or others, of the README are more polite, then please by all means make them. I am not the most skilled at this.
