### PR TITLE
Select input after crm candidate insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ packages. Users of `selectrum-prescient` can update to configure
 `selectrum-prescient-secondary-highlight` ([#455]).
 
 ### Enhancements
+* When using `selectrum-insert-current-candidate` in a
+  `completing-read-multiple` session, the input will get selected
+  after candidate insertion ([#494]).
 * File name completions using `selectrum-completion-in-region` have
   been improved. When starting with an empty input the completion
   starts at `default-directory` and file names are quoted in modes
@@ -66,6 +69,7 @@ packages. Users of `selectrum-prescient` can update to configure
 [#466]: https://github.com/raxod502/selectrum/pull/466
 [#479]: https://github.com/raxod502/selectrum/pull/479
 [#488]: https://github.com/raxod502/selectrum/pull/488
+[#494]: https://github.com/raxod502/selectrum/pull/494
 
 ## 3.1 (released 2021-02-21)
 ### Deprecated

--- a/selectrum.el
+++ b/selectrum.el
@@ -1884,8 +1884,7 @@ started from."
                     (cond (minibuffer-completing-file-name
                            (not (selectrum--at-existing-prompt-path-p)))
                           (t
-                           (not (string-empty-p
-                                 (minibuffer-contents))))))
+                           (not (string-empty-p selectrum--virtual-input)))))
                0
              -1)
            (1- (length selectrum--refined-candidates))))))
@@ -2001,7 +2000,7 @@ indices."
     (let ((index (selectrum--index-for-arg arg)))
       (if (or (not selectrum--match-is-required)
               (string-empty-p
-               (minibuffer-contents))
+               selectrum--virtual-input)
               (and index (>= index 0))
               (if minibuffer-completing-file-name
                   (selectrum--at-existing-prompt-path-p)
@@ -2051,6 +2050,9 @@ refresh."
                                   (point-max))
                    (insert full))
                   (t
+                   ;; Select input after crm insertion.
+                   (setq-local selectrum--repeat t)
+                   (setq-local selectrum--current-candidate-index -1)
                    (goto-char
                     (if (re-search-backward crm-separator
                                             (minibuffer-prompt-end) t)

--- a/selectrum.el
+++ b/selectrum.el
@@ -595,7 +595,7 @@ as symbol constituents.")
 ;;; Session state
 
 (defvar-local selectrum--last-buffer nil
-  "The buffer that was current before the active session")
+  "The buffer that was current before the active session.")
 
 (defvar-local selectrum--candidates-overlay nil
   "Overlay used to display current candidates.")
@@ -664,9 +664,9 @@ input that does not match any of the displayed candidates.")
   "Prefix argument given to last interactive command that invoked Selectrum.")
 
 (defvar-local selectrum--last-input nil
-  "Input of last Selectrum session. This is different from
-`selectrum--previous-input-string' which reflects the previous
-input within a session.")
+  "Input of last Selectrum session.
+This is different from `selectrum--previous-input-string' which
+reflects the previous input within a session.")
 
 (defvar-local selectrum--repeat nil
   "Non-nil means try to restore the minibuffer state during setup.


### PR DESCRIPTION
For crm the UI interaction is smoother when selecting the input after
insertion, see https://github.com/oantolin/embark/issues/183

