### PR TITLE
selectrum--exit-with: Fix no remaining candidate case for crm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ packages. Users of `selectrum-prescient` can update to configure
 * When doing `completing-read-multiple`, selecting an additional
   candidate and exiting by pressing `RET` no longer fails when there
   are existing candidates already selected using `TAB` ([#460]).
+* When all candidates were selected in a completing-read-multiple
+  session the return value wasn't correct, which has been fixed
+  ([#495]).
 
 [#16]: https://github.com/raxod502/selectrum/issues/16
 [#304]: https://github.com/raxod502/selectrum/issues/304
@@ -70,6 +73,7 @@ packages. Users of `selectrum-prescient` can update to configure
 [#479]: https://github.com/raxod502/selectrum/pull/479
 [#488]: https://github.com/raxod502/selectrum/pull/488
 [#494]: https://github.com/raxod502/selectrum/pull/494
+[#495]: https://github.com/raxod502/selectrum/pull/495
 
 ## 3.1 (released 2021-02-21)
 ### Deprecated

--- a/selectrum.el
+++ b/selectrum.el
@@ -1932,40 +1932,41 @@ Or if there is an active region, save the region to kill ring."
   "Exit minibuffer with given CANDIDATE.
 If `selectrum--is-crm-session' is non-nil exit with the choosen candidates
 plus CANDIDATE."
-  (let* ((result (cond ((and selectrum--is-crm-session
-                             (string-match crm-separator
-                                           selectrum--previous-input-string))
-                        (let* ((previous-input-string
-                                selectrum--previous-input-string)
-                               (separator
-                                crm-separator)
-                               (full-candidate
-                                (selectrum--get-full candidate))
-                               (crm
-                                (if (and selectrum--current-candidate-index
-                                         (< selectrum--current-candidate-index
-                                            0))
-                                    candidate
-                                  (with-temp-buffer
-                                    (insert previous-input-string)
-                                    (goto-char (point-min))
-                                    (while (re-search-forward
-                                            separator nil t))
-                                    (delete-region (point) (point-max))
-                                    (insert full-candidate)
-                                    (buffer-string)))))
-                          (dolist (cand (split-string crm separator t))
-                            (apply #'run-hook-with-args
-                                   'selectrum-candidate-selected-hook
-                                   (selectrum--get-full cand)
-                                   selectrum--read-args))
-                          crm))
-                       (t
-                        (apply #'run-hook-with-args
-                               'selectrum-candidate-selected-hook
-                               candidate
-                               selectrum--read-args)
-                        (selectrum--get-full candidate))))
+  (let* ((result
+          (cond ((and selectrum--is-crm-session
+                      (string-match crm-separator
+                                    selectrum--previous-input-string))
+                 (let* ((previous-input-string
+                         selectrum--previous-input-string)
+                        (separator
+                         crm-separator)
+                        (full-candidate
+                         (selectrum--get-full candidate))
+                        (crm
+                         (if (or (not selectrum--current-candidate-index)
+                                 (< selectrum--current-candidate-index
+                                    0))
+                             candidate
+                           (with-temp-buffer
+                             (insert previous-input-string)
+                             (goto-char (point-min))
+                             (while (re-search-forward
+                                     separator nil t))
+                             (delete-region (point) (point-max))
+                             (insert full-candidate)
+                             (buffer-string)))))
+                   (dolist (cand (split-string crm separator t))
+                     (apply #'run-hook-with-args
+                            'selectrum-candidate-selected-hook
+                            (selectrum--get-full cand)
+                            selectrum--read-args))
+                   crm))
+                (t
+                 (apply #'run-hook-with-args
+                        'selectrum-candidate-selected-hook
+                        candidate
+                        selectrum--read-args)
+                 (selectrum--get-full candidate))))
          (inhibit-read-only t))
     (erase-buffer)
     (insert (if (string-empty-p result)


### PR DESCRIPTION
When all candidates were selected in a completing-read-multiple session the return value wasn't correct, which has been fixed.