### PR TITLE
Add selectrum-backward-kill-sexp command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,12 @@ packages. Users of `selectrum-prescient` can update to configure
 * `selectrum-completion-in-region` does support cycling (as configured
   per `completion-cycle-threshold`) now ([#419], [#456]).
 
-
 ### Bugs fixed
+* When using `backward-kill-sexp` for the last part of inputs in file
+  prompts, you would get an error message and the trailing space of
+  the prompt would get included for the killed text. This got fixed by
+  introducing the `selectrum-backward-kill-sexp` command ([#498],
+  [#499]).
 * When using `marginalia-mode` there would be an arrow in the fringe
   for the currently selected candidate which has been fixed ([#450],
   [#488]).
@@ -74,6 +78,8 @@ packages. Users of `selectrum-prescient` can update to configure
 [#488]: https://github.com/raxod502/selectrum/pull/488
 [#494]: https://github.com/raxod502/selectrum/pull/494
 [#495]: https://github.com/raxod502/selectrum/pull/495
+[#498]: https://github.com/raxod502/selectrum/issues/498
+[#499]: https://github.com/raxod502/selectrum/pull/495
 
 ## 3.1 (released 2021-02-21)
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -213,12 +213,12 @@ editing bindings. So, for example:
 * To delete your current input, just use `C-a C-k` or `C-S-backspace`
   (bound to `kill-whole-line`).
 * To edit by word units use `M-DEL` like usual. To go up a directory
-  you can use `C-M-DEL` (bound to `backward-kill-sexp`). Be aware that
-  on some Linux distributions, this binding is used to kill the X
-  server, which can force-quit all programs you opened. Therefore,
-  accidentally killing the X server can cause data corruption and loss
-  of unsaved work. In such cases, you can instead use `ESC C-DEL`,
-  which Emacs helpfully binds by default.
+  you can use `C-M-DEL` (bound to `selectrum-backward-kill-sexp`). Be
+  aware that on some Linux distributions, this binding is used to kill
+  the X server, which can force-quit all programs you opened.
+  Therefore, accidentally killing the X server can cause data
+  corruption and loss of unsaved work. In such cases, you can instead
+  use `ESC C-DEL`, which Emacs helpfully binds by default.
 * To navigate to your home directory, you can just use `C-a C-k ~/`.
   Alternatively, like in default completion, you can type `~/` after a
   `/` to ignore the preceding input and move to the home directory.

--- a/selectrum.el
+++ b/selectrum.el
@@ -531,8 +531,10 @@ function and BODY opens the minibuffer."
       #'selectrum-kill-ring-save)
     (define-key map [remap previous-matching-history-element]
       #'selectrum-select-from-history)
-    (define-key map (kbd "C-M-DEL") #'backward-kill-sexp)
-    (define-key map (kbd "C-M-<backspace>") #'backward-kill-sexp)
+    (define-key map [remap backward-kill-sexp]
+      #'selectrum-backward-kill-sexp)
+    (define-key map (kbd "C-M-DEL") #'selectrum-backward-kill-sexp)
+    (define-key map (kbd "C-M-<backspace>") #'selectrum-backward-kill-sexp)
     (define-key map (kbd "C-j") #'selectrum-submit-exact-input)
     (define-key map (kbd "TAB") #'selectrum-insert-current-candidate)
     (define-key map (kbd "M-q") 'selectrum-cycle-display-style)
@@ -1918,6 +1920,17 @@ started from."
   (when selectrum--current-candidate-index
     (setq-local selectrum--current-candidate-index
                 (1- (length selectrum--refined-candidates)))))
+
+(defun selectrum-backward-kill-sexp (&optional arg)
+  "Selectrum wrapper for `backward-kill-sexp'.
+Behavior and ARG are the the same as for `backward-kill-sexp'."
+  (interactive "p")
+  ;; For Selectrum file prompts `backward-kill-sexp' would wrongly
+  ;; include trailing (read only) spaces as part of the input (see
+  ;; `selectrum--minibuffer-local-filename-syntax').
+  (save-restriction
+    (narrow-to-region (minibuffer-prompt-end) (point-max))
+    (backward-kill-sexp arg)))
 
 (defun selectrum-kill-ring-save ()
   "Save current candidate to kill ring.

--- a/selectrum.el
+++ b/selectrum.el
@@ -1923,7 +1923,7 @@ started from."
 
 (defun selectrum-backward-kill-sexp (&optional arg)
   "Selectrum wrapper for `backward-kill-sexp'.
-Behavior and ARG are the the same as for `backward-kill-sexp'."
+ARG is the same as for `backward-kill-sexp'."
   (interactive "p")
   ;; For Selectrum file prompts `backward-kill-sexp' would wrongly
   ;; include trailing (read only) spaces as part of the input (see


### PR DESCRIPTION
See #498 where an error was discovered by @mohkale [here](https://github.com/raxod502/selectrum/issues/498#issuecomment-803368243):

> backward-kill-sexp works well enough but when my current path is ~/ or even just {~/} or / I get a kill-region: Text is read-only: #<buffer *Minibuf-1*> which makes me think it's trying to delete the prompt?


