### PR TITLE
selectrum-default-candidates-preprocess-function: Sort by history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The format is based on [Keep a Changelog].
   title formatting is controlled by the customization variable
   `selectrum-group-format` and the faces `selectrum-group-separator`
   and `selectrum-group-title` ([#458], [#463]).
+* `selectrum-default-candidates-preprocess-function` sorts according
+  to the history now, such that recently used candidates appear first
+  ([#500]).
 
 ### Deprecated
 The faces `selectrum-primary-highlight` and
@@ -79,7 +82,8 @@ packages. Users of `selectrum-prescient` can update to configure
 [#494]: https://github.com/raxod502/selectrum/pull/494
 [#495]: https://github.com/raxod502/selectrum/pull/495
 [#498]: https://github.com/raxod502/selectrum/issues/498
-[#499]: https://github.com/raxod502/selectrum/pull/495
+[#499]: https://github.com/raxod502/selectrum/pull/499
+[#500]: https://github.com/raxod502/selectrum/pull/500
 
 ## 3.1 (released 2021-02-21)
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -228,10 +228,11 @@ editing bindings. So, for example:
 
 ### Sorting and filtering
 
-The default sorting and filtering in Selectrum is quite primitive.
-First candidates are sorted alphabetically, and then they are filtered
-and highlighted using `completion-styles`. This default behavior is
-intended as a lowest common denominator that will definitely work.
+The default sorting and filtering in Selectrum is quite simple. First
+candidates are sorted by history position, then by length and then
+alphabetically. Afterwards they are filtered and highlighted using the
+`completion-styles`. This default behavior is intended as a lowest
+common denominator that will definitely work.
 
 However, it is strongly recommended that you customize
 `completion-styles` using


### PR DESCRIPTION
As recently discussed on reddit, icomplete/default completion [sorts by history](https://www.reddit.com/r/emacs/comments/m9avdn/orderless_selectrum_prescient_and_consult_basic/grniolf?utm_source=share&utm_medium=web2x&context=3). I propose we do the same in the default Selectrum sorting function for consistency. And it is also kind of nice since this gives some kind of cheap emulation of prescient sorting, arguably without the more sophisticated frecency calculation.