### PR TITLE
add message for emacs-dir for test scripts

### DIFF
--- a/test/install.el
+++ b/test/install.el
@@ -1,7 +1,6 @@
 ;; -*- lexical-binding: t -*-
 
 ;; Use a temporary emacs.d directory for testing
-(delete-directory "/tmp/test-emacs.d")
 (setq user-emacs-directory "/tmp/test-emacs.d/")
 
 ;; Setup package archive
@@ -18,3 +17,5 @@
 (package-install 'orderless)
 (package-install 'selectrum)
 (package-install 'selectrum-prescient)
+
+(message "packages are installed in tmp/test-emacs.d ...")

--- a/test/install.el
+++ b/test/install.el
@@ -18,4 +18,4 @@
 (package-install 'selectrum)
 (package-install 'selectrum-prescient)
 
-(message "packages are installed in /tmp/test-emacs.d ...")
+(message "Installed packages to /tmp/test-emacs.d/")

--- a/test/install.el
+++ b/test/install.el
@@ -18,4 +18,4 @@
 (package-install 'selectrum)
 (package-install 'selectrum-prescient)
 
-(message "packages are installed in tmp/test-emacs.d ...")
+(message "packages are installed in /tmp/test-emacs.d ...")

--- a/test/install.el
+++ b/test/install.el
@@ -1,6 +1,7 @@
 ;; -*- lexical-binding: t -*-
 
 ;; Use a temporary emacs.d directory for testing
+(delete-directory "/tmp/test-emacs.d")
 (setq user-emacs-directory "/tmp/test-emacs.d/")
 
 ;; Setup package archive


### PR DESCRIPTION
I'm not sure this is more widely needed, or the best approach, but this is to get around the issue that if one is using the test scripts, and has the tmp directory hanging around for awhile, the packages can get out of date.