### PR TITLE
Deprecate selectrum-get-current-input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
 ## Unreleased
+### Deprecated
+* The function `selectrum-get-current-input` is deprecated ([#537]).
+
 ### Breaking changes
 * Support for Emacs versions older than 26.1 has been removed ([#454],
   [#465]).
@@ -141,6 +144,7 @@ The format is based on [Keep a Changelog].
 [#524]: https://github.com/raxod502/selectrum/pull/524
 [#528]: https://github.com/raxod502/selectrum/issues/528
 [#530]: https://github.com/raxod502/selectrum/pull/530
+[#537]: https://github.com/raxod502/selectrum/pull/537
 
 ## 3.1 (released 2021-02-21)
 ### Deprecated

--- a/selectrum.el
+++ b/selectrum.el
@@ -746,6 +746,7 @@ candidate and return the candidate as displayed."
   (when selectrum-is-active
     (with-selected-window (active-minibuffer-window)
       (minibuffer-contents))))
+(make-obsolete 'selectrum-get-current-input nil "3.1")
 
 (defun selectrum-set-selected-candidate (&optional string)
   "Set currently selected candidate to STRING.


### PR DESCRIPTION
There is no reason to provide this function on top of
selectrum-is-active and minibuffer-contents.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
