### PR TITLE
Add to description of Prescient in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ more advanced filtering and sorting: 1. Prescient and 2. Orderless.
 ##### Alternative 1: Prescient
 
 Filtering and sorting can both be improved by installing the
-`selectrum-prescient` package from MELPA and adding the following to
-your init-file.
+[`selectrum-prescient`](https://github.com/raxod502/prescient.el)
+package from MELPA and adding the following to your init-file.
 
 ```elisp
 ;; to make sorting and filtering more intelligent
@@ -149,12 +149,20 @@ your init-file.
   the candidates are sorted by length. This algorithm turns out to do
   very well in practice while being fast and not very magical.
 * Your input is split on spaces into subqueries, each of which must
-  match as either a substring, a regexp, or an initialism (e.g. `ffap`
-  matches `find-file-at-point`) in order for a candidate to be
-  included. Again, this algorithm isn't optimal, but it does very well
-  in practice given its simplicity and speed.
-* The part of each candidate that matched your input is highlighted,
-  with the initials of an initialism highlighted in a second color.
+  (by default) match as either a substring, a regexp, or an initialism
+  (e.g. `ffap` matches `find-file-at-point`). The subqueries can match
+  a candidate in any order, but a candidate must match all subqueries
+  in order to remain in the filtered list of candidates.
+  * Other matching styles are available in addition to the default
+    three, and custom styles can be added by users.
+  * Filtering features can be toggled on the fly, such as whether to
+    use character/case folding or which matching styles are active.
+  * Optionally, fully matched candidates can be listed before
+    partially matched candidates while keeping the frecency-based
+    sorting.
+* The parts of each candidate that matched your input are highlighted,
+  with important sections within each part (such as the initials of an
+  initialism) highlighted in a second color.
 
 ##### Alternative 2: Orderless
 


### PR DESCRIPTION
Prescient has improved a bit since Selectrum was created, and I think it's worth describing it in a bit more detail.  It might also be worth describing Orderless in more detail too, but I don't know as much about that package.

- Add link to Prescient README in this section.
- Note that other filtering styles are available and that more can be added by users.
- Mention being able to toggle some of the filtering features on the
  fly, such as case/character folding or which filtering methods are
  active.
- Mention being able to list fully matched candidates before partially
  matched candidates.
- Note that sub-queries can match in any order, but that all queries
  must match.
- Note that multiple parts of a candidate can be highlighted.
- Tentatively remove warning about "optimality" of algorithm.
  Generally, if things work well in practice, they work well
  enough. This is my opinion.

Is there anything you would like changed?