### PR TITLE
Don't remap keyboard-quit in selectrum's keymap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,10 @@ The format is based on [Keep a Changelog].
   with `selectrum-read-library-name` will cause the first matching
   library name in the list of unfiltered candidates to be
   selected. ([#577], [#580])
+* Selectrum no longer remaps `C-g` when the function
+  `abort-minibuffers` is available.  Previously, this was done to
+  better support recursive minibuffers, but default Emacs now handles
+  this better. See [#569].
 
 [#16]: https://github.com/raxod502/selectrum/issues/16
 [#176]: https://github.com/raxod502/selectrum/issues/176
@@ -153,6 +157,7 @@ The format is based on [Keep a Changelog].
 [#528]: https://github.com/raxod502/selectrum/issues/528
 [#530]: https://github.com/raxod502/selectrum/pull/530
 [#537]: https://github.com/raxod502/selectrum/pull/537
+[#537]: https://github.com/raxod502/selectrum/pull/569
 [#577]: https://github.com/raxod502/selectrum/issues/577
 [#580]: https://github.com/raxod502/selectrum/pull/580
 [#581]: https://github.com/raxod502/selectrum/pull/581

--- a/selectrum.el
+++ b/selectrum.el
@@ -386,11 +386,17 @@ This option needs to be set before activating `selectrum-mode'."
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map minibuffer-local-map)
 
-    (define-key map [remap keyboard-quit] #'abort-recursive-edit)
-    ;; This is bound in `minibuffer-local-map' by loading `delsel', so
-    ;; we have to account for it too.
-    (define-key map [remap minibuffer-keyboard-quit]
-      #'abort-recursive-edit)
+    ;; Previously, we needed to explicitly bind `abort-recursive-edit'
+    ;; to handle recursive minibuffers, but the new function
+    ;; `abort-minibuffers' already handles them.
+    ;; `minibuffer-keyboard-quit' now uses this function.
+    (unless (fboundp 'abort-minibuffers)
+      (define-key map [remap keyboard-quit] #'abort-recursive-edit)
+      ;; This is bound in `minibuffer-local-map' by loading `delsel', so
+      ;; we have to account for it too.
+      (define-key map [remap minibuffer-keyboard-quit]
+        #'abort-recursive-edit))
+
     ;; Override both the arrow keys and C-n/C-p.
     (define-key map [remap previous-line]
       #'selectrum-previous-candidate)


### PR DESCRIPTION
These two remappings are not needed any more, since the keymap
inherits from minibuffer-local-map and they get in the way of
minibuffer-keyboard-quit's new functionality in Emacs 28.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
