### PR TITLE
Fix buffer error with selectrum-display-action

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -1401,8 +1401,7 @@ the update."
        '(face selectrum-current-candidate)))
     (let* ((count-info (selectrum--count-info))
            (window (if selectrum-display-action
-                       (and selectrum--refined-candidates
-                            (selectrum--get-display-window))
+                       (selectrum--get-display-window)
                      (active-minibuffer-window)))
            (minibuf-after-string (or (selectrum--format-default) " "))
            (inserted-res


### PR DESCRIPTION
This fixes the error described in [#571][1].

When using `selectrum-display-action`, `selectrum--update` would raise the following error when the candidate list is empty (eg calling `find-file` from an empty directory):

```
Error in post-command-hook (selectrum--update): (error "No buffer named  *selectrum*")
```

[1]: https://github.com/raxod502/selectrum/issues/571

Poking around in `selectrum.el`, I found this happens because `selectrum--update` uses `selectrum--display-action-buffer`:

``` elisp
(if selectrum-display-action
    ;; Insert candidates into action buffer.
    (with-current-buffer selectrum--display-action-buffer
      (erase-buffer)
      (insert inserted-string))
  ...)
```

`selectrum--display-action-buffer` is created in `selectrum--get-display-window`, but `selectrum--update` explicitly does not call `selectrum--get-display-window` when the candidate list is empty:

``` elisp
(let* (...
       (window (if selectrum-display-action
                   (and selectrum--refined-candidates
                        (selectrum--get-display-window))
                 (active-minibuffer-window)))
       ...)
  ...)
```

With my setup, removing the check fixes the problem.

I'm not sure if this is a general solution—I assume the check is there for a reason, but I don't know what that is :).

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
