### PR TITLE
Fix `selectrum-read-library-name`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ The format is based on [Keep a Changelog].
   previously deleted multiple instances of the moved candidate.  It
   now correctly moves all instances to the front, maintaining their
   relative order.  This was first mentioned in [#580].  See [#581].
+* Using `selectrum-submit-exact-input` when completing library names
+  with `selectrum-read-library-name` will cause the first matching
+  library name in the list of unfiltered candidates to be
+  selected. ([#577], [#580])
 
 [#16]: https://github.com/raxod502/selectrum/issues/16
 [#176]: https://github.com/raxod502/selectrum/issues/176
@@ -149,6 +153,7 @@ The format is based on [Keep a Changelog].
 [#528]: https://github.com/raxod502/selectrum/issues/528
 [#530]: https://github.com/raxod502/selectrum/pull/530
 [#537]: https://github.com/raxod502/selectrum/pull/537
+[#577]: https://github.com/raxod502/selectrum/issues/577
 [#580]: https://github.com/raxod502/selectrum/pull/580
 [#581]: https://github.com/raxod502/selectrum/pull/581
 


### PR DESCRIPTION
- Use `find-library-source-path` in Emacs versions starting with 28.1.

  The variable `find-function-source-path` was renamed to
  `find-library-source-path` starting with Emacs 28.1.

- Always use a text property in `selectrum-read-library-name`.

  This fixes #577.  If the user chooses a matching candidate with
  `selectrum-submit-exact-input`, then the returned candidate won't
  have the needed property.  In that case, we select the first item in
  the propertized candidate list that is `equal` to the selected
  candidate.

- Update changelog.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
