### PR TITLE
Fix `selectrum--move-to-front-destructive`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,10 @@ The format is based on [Keep a Changelog].
 * When all candidates were selected in a completing-read-multiple
   session the return value wasn't correct, which has been fixed
   ([#495]).
+* Fix `selectrum--move-to-front-destructive`.  This function
+  previously deleted multiple instances of the moved candidate.  It
+  now correctly moves all instances to the front, maintaining their
+  relative order.  This was first mentioned in [#580].  See [#581].
 
 [#16]: https://github.com/raxod502/selectrum/issues/16
 [#176]: https://github.com/raxod502/selectrum/issues/176
@@ -145,6 +149,8 @@ The format is based on [Keep a Changelog].
 [#528]: https://github.com/raxod502/selectrum/issues/528
 [#530]: https://github.com/raxod502/selectrum/pull/530
 [#537]: https://github.com/raxod502/selectrum/pull/537
+[#580]: https://github.com/raxod502/selectrum/pull/580
+[#581]: https://github.com/raxod502/selectrum/pull/581
 
 ## 3.1 (released 2021-02-21)
 ### Deprecated

--- a/selectrum.el
+++ b/selectrum.el
@@ -651,9 +651,16 @@ return X."
   "Move ELT to front of LST, if present.
 Make comparisons using `equal'. Modify the input list
 destructively and return the modified list."
-  (if-let ((rest (member elt lst)))
-      (nconc (list (car rest)) (delete elt lst))
-    lst))
+  ;; We can't use something like "(cons elt (filter elt lst))"
+  ;; in case there are multiple instances of `elt' in `lst'.
+  (let ((matches)
+        (others))
+    (dolist (i lst)
+      (if (equal i elt)
+          (push i matches)
+        (push i others)))
+    ;; Maintain the order of the list.
+    (nconc (nreverse matches) (nreverse others))))
 
 (defmacro selectrum--minibuffer-with-setup-hook (fun &rest body)
   "Variant of `minibuffer-with-setup-hook' using a symbol and `fset'.


### PR DESCRIPTION
Instead of deleting all instances of an element before moving it to
the front, move all instances to the front.  This is important for
candidates that differ by text properties.
