### PR TITLE
Add :group parameter to selectrum-mode

### DIFF
--- a/selectrum.el
+++ b/selectrum.el
@@ -3102,6 +3102,7 @@ ARGS are standard as in all `:around' advice."
   (define-minor-mode selectrum-mode
     "Minor mode to use Selectrum for `completing-read'."
     :global t
+    :group 'selectrum
     (if selectrum-mode
         (progn
           ;; Make sure not to blow away saved variable values if mode


### PR DESCRIPTION
Hi Radon,

This fixes a byte-compiler warning when installing selectrum with `package.el`:

```
Compiling file /home/skangas/.emacs.d/package-quickstart.el at Mon Jan 10 05:33:47 2022
package-quickstart.el:2060:2170: Warning: defcustom for ‘selectrum-mode’ fails
    to specify containing group
```

See previous discussion on the Emacs bug tracker here:
https://debbugs.gnu.org/cgi/bugreport.cgi?bug=53153#14

Thanks!