### PR TITLE
Add commands to navigate by groups.  Add cycling to commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,10 @@ The format is based on [Keep a Changelog].
   ([#500]).
 * The face that is used when the mouse hovers over candidates can now
   be customized through `selectrum-mouse-highlight` ([#507]).
+* Add commands `selectrum-next-group` and `selectrum-previous-group`
+  ([#554] , [#588]).
+* Add cycling to navigation commands ([#570], [#588]) with user option
+  `selectrum-cycle-movement`.
 
 ### Enhancements
 * When using `selectrum-insert-current-candidate` in a
@@ -169,7 +173,9 @@ The format is based on [Keep a Changelog].
 [#528]: https://github.com/raxod502/selectrum/issues/528
 [#530]: https://github.com/raxod502/selectrum/pull/530
 [#537]: https://github.com/raxod502/selectrum/pull/537
+[#554]: https://github.com/raxod502/selectrum/issues/554
 [#569]: https://github.com/raxod502/selectrum/pull/569
+[#570]: https://github.com/raxod502/selectrum/issues/570
 [#571]: https://github.com/raxod502/selectrum/issues/571
 [#576]: https://github.com/raxod502/selectrum/issues/576
 [#577]: https://github.com/raxod502/selectrum/issues/577
@@ -179,6 +185,7 @@ The format is based on [Keep a Changelog].
 [#585]: https://github.com/raxod502/selectrum/issues/585
 [#586]: https://github.com/raxod502/selectrum/pull/586
 [#587]: https://github.com/raxod502/selectrum/pull/587
+[#588]: https://github.com/raxod502/selectrum/pull/588
 
 ## 3.1 (released 2021-02-21)
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ how to fix it.
 * *To navigate to a candidate:* use the standard motion commands
   (`<up>`, `<down>`, `C-v`, `M-v`, `M-<`, `M->`). If you prefer, you
   can use `C-p` and `C-n` instead of the arrow keys.
+* *To navigate to a group of candidates*: use `M-{` (remapped from
+  `backward-paragraph`) and `M-}` (remapped from `forward-paragraph`)
+  to move to the previous and next group, respectively. You can also
+  use `C-M-p` and `C-M-n`.
 * *To accept the currently selected candidate:* type `RET`/`C-m`.
   (With a prefix argument, accept instead the candidate at that point
   in the list, counting from one. See `selectrum-show-indices`. The


### PR DESCRIPTION
- Add option `selectrum-cycle-movement`.  When enabled, navigation
  commands wrap around.  Requested in #570.
- Add commands to navigate by groups (with optional cycling).
  Requested in #554.