### PR TITLE
Mention the `:extend` face attribute for Emacs 27+.

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,9 +363,13 @@ used refinement function. The built-in `completion-styles` support the
 * The currently selected candidate is highlighted with the face
   `selectrum-current-candidate`. If you don't like the color, you can
   adjust it to taste.
-  * By default, only the displayed text is highlighted. If you wish to
-    extend the highlight until the margin, you can set
-    `selectrum-extend-current-candidate-highlight` to `t`.
+  * By default, only the displayed text is highlighted.  If
+    annotations are being used, then the highlighting is extended
+    until the margin. If you wish to always extend the highlighting,
+    you can set `selectrum-extend-current-candidate-highlight` to `t`.
+    Note that in Emacs 27 and greater, the face
+    `selectrum-current-candidate` must have the `:extend` attribute
+    set to `t` for this feature to work.
 * By default, the total number of matches are shown before the prompt.
   This behavior can be customized using `selectrum-count-style`.
 * You can show the indices of displayed candidates by customizing

--- a/selectrum.el
+++ b/selectrum.el
@@ -61,7 +61,12 @@
 
 (defface selectrum-current-candidate
   '((t :inherit highlight :extend t))
-  "Face used to highlight the currently selected candidate."
+  "Face used to highlight the currently selected candidate.
+
+In Emacs 27 and greater, this face is assumed to have the
+`:extend' attribute set to a non-nil value (the default).
+ This is expected by user options like
+`selectrum-extend-current-candidate-highlight'."
   :group 'selectrum-faces)
 
 (defface selectrum-completion-annotation
@@ -360,11 +365,14 @@ setting."
 (defcustom selectrum-extend-current-candidate-highlight 'auto
   "Whether to extend highlighting of the current candidate until the margin.
 
-When set to nil only highlight the displayed text. When set to
-`auto' (the default) Selectrum will only highlight the displayed
-text unless the session defines any annotations in which case the
-highlighting is automatically extended. Any other non-nil value
-means to always extend the highlighting."
+When set to nil, only highlight the displayed text. When set to
+`auto' (the default), the highlighting is automatically extended
+when the session defines any annotations. Any other non-nil value
+means to always extend the highlighting.
+
+In Emacs 27 and greater, this option requires that the face
+`selectrum-current-candidate' have a non-nil value for the
+`:extend' attribute (the default)."
   :type '(choice (const :tag "Automatic" auto) boolean))
 
 (defcustom selectrum-files-select-input-dirs nil


### PR DESCRIPTION
- In the documentation string of the user option
  `selectrum-extend-current-candidate-highlight`
- In the documentation string of the face
  `selectrum-current-candidate`
- In README.md